### PR TITLE
fix(tests): browser_bindings no-such-table in agent-mode protocol tests

### DIFF
--- a/tests/unit/channels/test_opencli_channel.py
+++ b/tests/unit/channels/test_opencli_channel.py
@@ -531,7 +531,7 @@ async def test_collect_agent_mode_http_success(channel):
 
 
 @pytest.mark.asyncio
-async def test_collect_agent_mode_ws_protocol_not_implemented(channel):
+async def test_collect_agent_mode_ws_protocol_not_implemented(channel, db_engine):
     """Agent mode with ws protocol returns fail (not yet implemented)."""
     from unittest.mock import create_autospec
 
@@ -553,6 +553,7 @@ async def test_collect_agent_mode_ws_protocol_not_implemented(channel):
     with (
         patch("backend.browser_pool.get_pool", return_value=mock_pool),
         patch("backend.config.get_settings", return_value=mock_settings),
+        patch("backend.database.AsyncSessionLocal", _sessionmaker(db_engine)),
     ):
         result = await channel.collect(
             {"site": "example.com", "command": "list"}, {}
@@ -563,7 +564,7 @@ async def test_collect_agent_mode_ws_protocol_not_implemented(channel):
 
 
 @pytest.mark.asyncio
-async def test_collect_agent_mode_unknown_protocol(channel):
+async def test_collect_agent_mode_unknown_protocol(channel, db_engine):
     """Agent mode with unknown protocol returns fail."""
     from unittest.mock import create_autospec
 
@@ -584,6 +585,7 @@ async def test_collect_agent_mode_unknown_protocol(channel):
     with (
         patch("backend.browser_pool.get_pool", return_value=mock_pool),
         patch("backend.config.get_settings", return_value=mock_settings),
+        patch("backend.database.AsyncSessionLocal", _sessionmaker(db_engine)),
     ):
         result = await channel.collect(
             {"site": "example.com", "command": "list"}, {}


### PR DESCRIPTION
两测试没patch backend.database.AsyncSessionLocal,导致真查未迁移DB报no such table: browser_bindings。main分支已连续多次CI因此挂红。照同文件其他agent-mode测试的写法补patch。