### PR TITLE
feat: implement automation pipeline (07/08/09 + capability projection)

### DIFF
--- a/backend/api/v1/__init__.py
+++ b/backend/api/v1/__init__.py
@@ -10,6 +10,7 @@ from backend.api.v1 import (
     control,
     cookies,
     dashboard,
+    evidence,
     model_defaults,
     nodes,
     notifications,
@@ -53,6 +54,7 @@ v1_router.include_router(skill_bridge.router)
 v1_router.include_router(skill_record.router)
 v1_router.include_router(webhooks.router)
 v1_router.include_router(workflows.router)
+v1_router.include_router(evidence.router)
 v1_router.include_router(notifications.router)
 v1_router.include_router(workers.router)
 v1_router.include_router(dashboard.router)

--- a/backend/api/v1/evidence.py
+++ b/backend/api/v1/evidence.py
@@ -1,0 +1,119 @@
+# ruff: noqa: N815, UP045
+"""EvidenceBatch projection endpoints.
+
+Read-only projection routes for evidence batches, batch detail, and full run
+projection. These routes do not dispatch workers and never stream raw
+records. They are meant to back Canvas run-trace workbenches and AI clients
+that need to cite evidence batch references.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.database import get_db
+from backend.schemas.common import ApiResponse
+from backend.schemas.evidence import (
+    EvidenceBatchDetailResponse,
+    EvidenceBatchListResponse,
+    EvidenceProjectionResponse,
+)
+from backend.services import evidence_service
+
+router = APIRouter(prefix="/workflows/runs", tags=["evidence"])
+
+
+def _split_include(value: Optional[str]) -> list[str]:
+    if value is None:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+@router.get(
+    "/{run_id}/evidence-batches",
+    response_model=ApiResponse[EvidenceBatchListResponse],
+)
+async def list_run_evidence_batches(
+    run_id: str,
+    node_id: Optional[str] = Query(default=None, alias="nodeId"),
+    source_group: Optional[str] = Query(default=None, alias="sourceGroup"),
+    cursor: Optional[str] = Query(default=None),
+    limit: Optional[int] = Query(default=None, ge=1, le=200),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[EvidenceBatchListResponse]:
+    """List evidence batch summaries for a workflow run with cursor pagination."""
+
+    try:
+        result = await evidence_service.list_evidence_batches(
+            run_id,
+            node_id=node_id,
+            source_group=source_group,
+            cursor=cursor,
+            limit=limit,
+            session=db,
+        )
+    except evidence_service.EvidenceRunNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return ApiResponse.ok(result)
+
+
+@router.get(
+    "/{run_id}/evidence-batches/{batch_id}",
+    response_model=ApiResponse[EvidenceBatchDetailResponse],
+)
+async def get_run_evidence_batch(
+    run_id: str,
+    batch_id: str,
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[EvidenceBatchDetailResponse]:
+    """Return the detail projection for a single evidence batch."""
+
+    try:
+        result = await evidence_service.get_evidence_batch(run_id, batch_id, session=db)
+    except evidence_service.EvidenceRunNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except evidence_service.EvidenceBatchNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return ApiResponse.ok(result)
+
+
+@router.get(
+    "/{run_id}/projection",
+    response_model=ApiResponse[EvidenceProjectionResponse],
+)
+async def get_run_projection(
+    run_id: str,
+    include: Optional[str] = Query(
+        default=None,
+        description=(
+            "Comma-separated optional sections: clusters, missingSources, "
+            "summaries, conflicts."
+        ),
+    ),
+    node_id: Optional[str] = Query(default=None, alias="nodeId"),
+    source_group: Optional[str] = Query(default=None, alias="sourceGroup"),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[EvidenceProjectionResponse]:
+    """Return the evidence projection for a workflow run.
+
+    Optional sections are opt-in via ``include``. Unsupported include values
+    return ``400`` to keep the projection surface explicit.
+    """
+
+    includes = _split_include(include)
+    try:
+        result = await evidence_service.build_run_projection(
+            run_id,
+            include=includes,
+            node_id=node_id,
+            source_group=source_group,
+            session=db,
+        )
+    except evidence_service.EvidenceRunNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except evidence_service.EvidenceUnsupportedIncludeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ApiResponse.ok(result)

--- a/backend/api/v1/workers.py
+++ b/backend/api/v1/workers.py
@@ -1,16 +1,16 @@
 import re
-from urllib.parse import urlparse
 from typing import Literal
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.browser_pool import get_pool
 from backend.config import get_settings
 from backend.database import get_db
 from backend.schemas.common import ApiResponse
-from backend.browser_pool import get_pool
 
 router = APIRouter(prefix="/workers", tags=["workers"])
 
@@ -19,6 +19,69 @@ def _inspect_workers() -> tuple[dict, dict]:
     from backend.worker.celery_app import celery_app
     inspect = celery_app.control.inspect(timeout=3)
     return inspect.stats() or {}, inspect.active() or {}
+
+
+class BrowserWorkerRegisterRequest(BaseModel):
+    worker_id: str
+    endpoint: str
+    capacity: int = 1
+    status: Literal["online", "offline", "draining"] = "online"
+    node_type: Literal["docker", "shell"] = "docker"
+    capabilities: list[str] = []
+
+
+@router.post("/browser-workers/register", response_model=ApiResponse[dict])
+async def register_browser_worker(body: BrowserWorkerRegisterRequest) -> ApiResponse:
+    """Register browser-worker capacity for routing compiled browser tasks."""
+    if body.capacity < 1:
+        raise HTTPException(status_code=400, detail="capacity must be at least 1")
+    pool = get_pool()
+    worker = pool.register_worker(
+        body.worker_id,
+        body.endpoint.rstrip("/"),
+        capacity=body.capacity,
+        status=body.status,
+        node_type=body.node_type,
+        capabilities=body.capabilities,
+    )
+    return ApiResponse.ok({
+        "workerId": worker.worker_id,
+        "endpoint": worker.endpoint,
+        "capacity": worker.capacity,
+        "active": worker.active,
+        "available": worker.available,
+        "status": worker.status,
+        "nodeType": worker.node_type,
+        "capabilities": list(worker.capabilities),
+    })
+
+
+@router.get("/browser-workers", response_model=ApiResponse[list[dict]])
+async def list_browser_workers() -> ApiResponse:
+    """Return registered browser-worker capacity without profile secrets."""
+    pool = get_pool()
+    return ApiResponse.ok([
+        {
+            "workerId": worker.worker_id,
+            "endpoint": worker.endpoint,
+            "capacity": worker.capacity,
+            "active": worker.active,
+            "available": worker.available,
+            "status": worker.status,
+            "nodeType": worker.node_type,
+            "capabilities": list(worker.capabilities),
+        }
+        for worker in pool.worker_capacity()
+    ])
+
+
+@router.delete("/browser-workers/{worker_id}", response_model=ApiResponse[dict])
+async def unregister_browser_worker(worker_id: str) -> ApiResponse:
+    """Remove a browser-worker registration while preserving its endpoint."""
+    removed = get_pool().unregister_worker(worker_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Browser worker not found")
+    return ApiResponse.ok({"workerId": worker_id, "removed": True})
 
 
 @router.get("", response_model=ApiResponse[list[dict]])
@@ -80,7 +143,9 @@ async def chrome_pool_status() -> ApiResponse:
             "container_status": _container_status(urlparse(ep).hostname or ""),
             "mode": pool.get_mode(ep),
             "agent_url": pool.get_agent_url(ep) if isinstance(pool, LocalBrowserPool) else None,
-            "agent_protocol": pool.get_agent_protocol(ep) if isinstance(pool, LocalBrowserPool) else None,
+            "agent_protocol": (
+                pool.get_agent_protocol(ep) if isinstance(pool, LocalBrowserPool) else None
+            ),
         }
         for ep in pool.endpoints
     ]
@@ -103,6 +168,7 @@ async def update_endpoint_mode(
 ) -> ApiResponse:
     """Update the connection mode (bridge/cdp) for an agent pool endpoint."""
     import base64
+
     from backend.models.browser import BrowserInstance
 
     try:

--- a/backend/browser_pool.py
+++ b/backend/browser_pool.py
@@ -18,10 +18,34 @@ a specific site (e.g. only chrome-2 is logged into Twitter).
 
 import asyncio
 import logging
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BrowserWorker:
+    """Registered browser-worker capacity advertised by a container or host."""
+
+    worker_id: str
+    endpoint: str
+    capacity: int = 1
+    active: int = 0
+    status: str = "online"
+    node_type: str = "docker"
+    capabilities: tuple[str, ...] = ()
+
+    @property
+    def available(self) -> int:
+        return max(0, self.capacity - self.active)
+
+
+class BrowserCapacityError(RuntimeError):
+    """Raised when no registered browser worker can accept a lease."""
+
+    code = "missing_worker_capacity"
 
 
 class LocalBrowserPool:
@@ -51,6 +75,9 @@ class LocalBrowserPool:
         self._agent_protocols: dict[str, str | None] = {ep: None for ep in endpoints}
         # node_type per endpoint: "docker" (started in container) | "shell" (native process)
         self._node_types: dict[str, str] = {ep: "docker" for ep in endpoints}
+        self._workers: dict[str, BrowserWorker] = {
+            ep: BrowserWorker(worker_id=ep, endpoint=ep) for ep in endpoints
+        }
         logger.info(
             "BrowserPool (local): %d Chrome instance(s): %s",
             self._total,
@@ -154,6 +181,60 @@ class LocalBrowserPool:
         self._node_types[endpoint] = node_type
         logger.info("BrowserPool: endpoint %s node_type set to %s", endpoint, node_type)
 
+    def worker_capacity(self) -> list[BrowserWorker]:
+        """Return the registered browser-worker capacity view."""
+        return list(self._workers.values())
+
+    def register_worker(
+        self,
+        worker_id: str,
+        endpoint: str,
+        *,
+        capacity: int = 1,
+        status: str = "online",
+        node_type: str = "docker",
+        capabilities: list[str] | tuple[str, ...] = (),
+    ) -> BrowserWorker:
+        """Register or update a worker and its browser capacity."""
+        if capacity < 1:
+            raise ValueError("capacity must be at least 1")
+        if endpoint not in self._slots:
+            self.add_endpoint(endpoint)
+        current = self._workers.get(worker_id)
+        active = current.active if current else 0
+        worker = BrowserWorker(
+            worker_id=worker_id,
+            endpoint=endpoint,
+            capacity=capacity,
+            active=min(active, capacity),
+            status=status,
+            node_type=node_type,
+            capabilities=tuple(capabilities),
+        )
+        self._workers[worker_id] = worker
+        self._node_types[endpoint] = node_type
+        logger.info(
+            "BrowserPool: worker %s registered at %s (capacity=%d)",
+            worker_id,
+            endpoint,
+            capacity,
+        )
+        return worker
+
+    def unregister_worker(self, worker_id: str) -> bool:
+        """Remove a worker registration without removing its browser endpoint."""
+        return self._workers.pop(worker_id, None) is not None
+
+    def get_worker(self, worker_id: str) -> BrowserWorker | None:
+        return self._workers.get(worker_id)
+
+    def available_worker_capacity(self) -> int:
+        return sum(worker.available for worker in self._workers.values())
+
+    @property
+    def workers(self) -> list[BrowserWorker]:
+        return self.worker_capacity()
+
     def add_endpoint(self, endpoint: str) -> None:
         """Hot-add a new Chrome instance to the pool without restarting."""
         if endpoint in self._slots:
@@ -165,6 +246,10 @@ class LocalBrowserPool:
         self._agent_urls.setdefault(endpoint, None)
         self._agent_protocols.setdefault(endpoint, None)
         self._node_types.setdefault(endpoint, "docker")
+        self._workers.setdefault(
+            endpoint,
+            BrowserWorker(worker_id=endpoint, endpoint=endpoint),
+        )
         self._total += 1
         logger.info("BrowserPool: added endpoint %s (total: %d)", endpoint, self._total)
 
@@ -177,6 +262,11 @@ class LocalBrowserPool:
         self._agent_urls.pop(endpoint, None)
         self._agent_protocols.pop(endpoint, None)
         self._node_types.pop(endpoint, None)
+        self._workers = {
+            worker_id: worker
+            for worker_id, worker in self._workers.items()
+            if worker.endpoint != endpoint
+        }
         self._total -= 1
         logger.info("BrowserPool: removed endpoint %s (total: %d)", endpoint, self._total)
 
@@ -210,6 +300,9 @@ class RedisBrowserPool:
         self._endpoints = list(endpoints)
         self._redis_url = redis_url
         self._total = len(endpoints)
+        self._workers: dict[str, BrowserWorker] = {
+            ep: BrowserWorker(worker_id=ep, endpoint=ep) for ep in endpoints
+        }
 
     def _client(self):
         import redis.asyncio as aioredis  # type: ignore[import]
@@ -273,6 +366,63 @@ class RedisBrowserPool:
                 await r.rpush(release_key, ep)
             logger.debug("Chrome released (Redis): %s", ep)
 
+    def register_worker(
+        self,
+        worker_id: str,
+        endpoint: str,
+        *,
+        capacity: int = 1,
+        status: str = "online",
+        node_type: str = "docker",
+        capabilities: list[str] | tuple[str, ...] = (),
+    ) -> BrowserWorker:
+        """Register or update worker metadata for a distributed pool."""
+        if capacity < 1:
+            raise ValueError("capacity must be at least 1")
+        if endpoint not in self._endpoints:
+            self._endpoints.append(endpoint)
+            self._total += 1
+        current = self._workers.get(worker_id)
+        worker = BrowserWorker(
+            worker_id=worker_id,
+            endpoint=endpoint,
+            capacity=capacity,
+            active=min(current.active, capacity) if current else 0,
+            status=status,
+            node_type=node_type,
+            capabilities=tuple(capabilities),
+        )
+        self._workers[worker_id] = worker
+        logger.info(
+            "BrowserPool (Redis): worker %s registered at %s (capacity=%d)",
+            worker_id,
+            endpoint,
+            capacity,
+        )
+        return worker
+
+    def unregister_worker(self, worker_id: str) -> bool:
+        return self._workers.pop(worker_id, None) is not None
+
+    def get_worker(self, worker_id: str) -> BrowserWorker | None:
+        return self._workers.get(worker_id)
+
+    def worker_capacity(self) -> list[BrowserWorker]:
+        return list(self._workers.values())
+
+    def available_worker_capacity(self) -> int:
+        return sum(worker.available for worker in self._workers.values())
+
+    @property
+    def workers(self) -> list[BrowserWorker]:
+        return self.worker_capacity()
+
+    def get_mode(self, endpoint: str) -> str:
+        return "bridge"
+
+    def set_mode(self, endpoint: str, mode: str) -> None:
+        logger.info("BrowserPool (Redis): endpoint %s mode set to %s", endpoint, mode)
+
     @property
     def total(self) -> int:
         return self._total
@@ -286,7 +436,7 @@ class RedisBrowserPool:
         return list(self._endpoints)
 
     def available_for(self, endpoint: str) -> bool:
-        return endpoint in self._endpoints  # approximate; real check would need Redis
+        return endpoint in self._endpoints
 
 
 # ── Module-level singleton ────────────────────────────────────────────────────

--- a/backend/migrations/versions/aa1b2c3d4e5f_add_browser_worker_resources.py
+++ b/backend/migrations/versions/aa1b2c3d4e5f_add_browser_worker_resources.py
@@ -1,0 +1,68 @@
+"""Alembic migration for browser worker profile/session resources."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "aa1b2c3d4e5f"
+down_revision = "z6u7v8w9x0y1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "profile_bindings",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("profile_id", sa.String(length=255), nullable=False),
+        sa.Column("site", sa.String(length=100), nullable=False),
+        sa.Column("browser_endpoint", sa.String(length=255), nullable=False),
+        sa.Column("mutation_mode", sa.String(length=20), nullable=False, server_default="read"),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("profile_id", name="uq_profile_bindings_profile_id"),
+    )
+    op.create_index("ix_profile_bindings_site", "profile_bindings", ["site"])
+
+    op.create_table(
+        "session_snapshots",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("profile_binding_id", sa.String(length=36), nullable=False),
+        sa.Column("blob_uri", sa.String(length=512), nullable=True),
+        sa.Column("snapshot_id", sa.String(length=255), nullable=False),
+        sa.Column("snapshot_type", sa.String(length=20), nullable=False, server_default="read"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("snapshot_id", name="uq_session_snapshots_snapshot_id"),
+    )
+    op.create_index(
+        "ix_session_snapshots_profile_binding_id",
+        "session_snapshots",
+        ["profile_binding_id"],
+    )
+
+    op.create_table(
+        "profile_locks",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("profile_binding_id", sa.String(length=36), nullable=False),
+        sa.Column("worker_slot_id", sa.String(length=255), nullable=False),
+        sa.Column("lock_token", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("profile_binding_id", name="uq_profile_locks_binding"),
+        sa.UniqueConstraint("lock_token", name="uq_profile_locks_lock_token"),
+    )
+    op.create_index("ix_profile_locks_profile_binding_id", "profile_locks", ["profile_binding_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_profile_locks_profile_binding_id", table_name="profile_locks")
+    op.drop_table("profile_locks")
+    op.drop_index("ix_session_snapshots_profile_binding_id", table_name="session_snapshots")
+    op.drop_table("session_snapshots")
+    op.drop_index("ix_profile_bindings_site", table_name="profile_bindings")
+    op.drop_table("profile_bindings")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,6 +1,12 @@
 from backend.models.agent import AIAgent
 from backend.models.base import TimestampMixin
-from backend.models.browser import BrowserBinding, BrowserInstance
+from backend.models.browser import (
+    BrowserBinding,
+    BrowserInstance,
+    ProfileBinding,
+    ProfileLock,
+    SessionSnapshot,
+)
 from backend.models.control_action import ControlActionRecord
 from backend.models.cookie_jar import CookieJarEntry
 from backend.models.edge_node import EdgeNode, EdgeNodeEvent
@@ -28,6 +34,9 @@ __all__ = [
     "AIAgent",
     "BrowserBinding",
     "BrowserInstance",
+    "ProfileBinding",
+    "ProfileLock",
+    "SessionSnapshot",
     "CookieJarEntry",
     "EdgeNode",
     "EdgeNodeEvent",

--- a/backend/models/browser.py
+++ b/backend/models/browser.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, Text, UniqueConstraint
+from sqlalchemy import Boolean, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.models.base import TimestampMixin
@@ -13,6 +13,46 @@ class BrowserBinding(TimestampMixin):
     browser_endpoint: Mapped[str] = mapped_column(String(255), nullable=False)
     site: Mapped[str] = mapped_column(String(100), nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class ProfileBinding(TimestampMixin):
+    """Saved profile identity shared by browser-worker containers."""
+
+    __tablename__ = "profile_bindings"
+    __table_args__ = (UniqueConstraint("profile_id", name="uq_profile_bindings_profile_id"),)
+
+    profile_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    site: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    browser_endpoint: Mapped[str] = mapped_column(String(255), nullable=False)
+    mutation_mode: Mapped[str] = mapped_column(String(20), nullable=False, default="read")
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class SessionSnapshot(TimestampMixin):
+    """Immutable session snapshot reference usable by read-only workers."""
+
+    __tablename__ = "session_snapshots"
+
+    profile_binding_id: Mapped[str] = mapped_column(
+        String(36), nullable=False, index=True
+    )
+    blob_uri: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    snapshot_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    snapshot_type: Mapped[str] = mapped_column(String(20), nullable=False, default="read")
+
+
+class ProfileLock(TimestampMixin):
+    """Database-visible profile mutation lease."""
+
+    __tablename__ = "profile_locks"
+    __table_args__ = (
+        UniqueConstraint("profile_binding_id", name="uq_profile_locks_binding"),
+    )
+
+    profile_binding_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    worker_slot_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    lock_token: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
 
 
 class BrowserInstance(TimestampMixin):

--- a/backend/schemas/evidence.py
+++ b/backend/schemas/evidence.py
@@ -1,0 +1,165 @@
+# ruff: noqa: N815, UP045
+"""Read-only projection contracts for EvidenceBatch results.
+
+These schemas describe what frontend and AI consumers can read from the workflow
+run axis. They do not dispatch workers, mutate state, or stream raw records.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+EvidenceBatchStatus = Literal[
+    "ready",
+    "partial",
+    "blocked",
+    "failed",
+    "completed",
+    "ingested",
+    "missing",
+]
+
+WorkflowProjectionInclude = Literal[
+    "clusters",
+    "missingSources",
+    "summaries",
+    "conflicts",
+]
+
+
+class EvidenceBatchSummary(BaseModel):
+    runId: str = Field(..., min_length=1)
+    nodeId: str = Field(..., min_length=1)
+    packageNodeId: Optional[str] = None
+    internalNodeId: Optional[str] = None
+    sourceGroup: Optional[str] = None
+    adapterTaskId: Optional[str] = None
+    traceId: Optional[str] = None
+    batchId: str = Field(..., min_length=1)
+    manifestUri: Optional[str] = None
+    odpRef: Optional[str] = None
+    itemCount: int = Field(0, ge=0)
+    recordCount: int = Field(0, ge=0)
+    status: EvidenceBatchStatus
+    createdAt: Optional[str] = None
+
+
+class EvidenceBatchListResponse(BaseModel):
+    runId: str = Field(..., min_length=1)
+    batches: list[EvidenceBatchSummary] = Field(default_factory=list)
+    nextCursor: Optional[str] = None
+
+
+class EvidenceBatchSourceCoverage(BaseModel):
+    sourceGroup: Optional[str] = None
+    site: Optional[str] = None
+    command: Optional[str] = None
+    itemCount: int = Field(0, ge=0)
+    recordCount: int = Field(0, ge=0)
+    status: EvidenceBatchStatus
+
+
+class EvidenceBatchDetail(BaseModel):
+    runId: str = Field(..., min_length=1)
+    batch: EvidenceBatchSummary
+    manifestUri: Optional[str] = None
+    odpRef: Optional[str] = None
+    recordCount: int = Field(0, ge=0)
+    itemCount: int = Field(0, ge=0)
+    sourceCoverage: list[EvidenceBatchSourceCoverage] = Field(default_factory=list)
+
+
+class EvidenceBatchDetailResponse(BaseModel):
+    runId: str = Field(..., min_length=1)
+    batch: EvidenceBatchSummary
+    manifestUri: Optional[str] = None
+    odpRef: Optional[str] = None
+    recordCount: int = Field(0, ge=0)
+    itemCount: int = Field(0, ge=0)
+    sourceCoverage: list[EvidenceBatchSourceCoverage] = Field(default_factory=list)
+
+
+class EvidenceClusterMember(BaseModel):
+    nodeId: str = Field(..., min_length=1)
+    sourceGroup: Optional[str] = None
+    recordId: Optional[str] = None
+    contentHash: Optional[str] = None
+    title: Optional[str] = None
+    url: Optional[str] = None
+    score: Optional[float] = None
+
+
+class EvidenceCluster(BaseModel):
+    clusterId: str = Field(..., min_length=1)
+    label: Optional[str] = None
+    size: int = Field(0, ge=0)
+    canonicalEvidence: Optional[EvidenceClusterMember] = None
+    members: list[EvidenceClusterMember] = Field(default_factory=list)
+    sourceGroups: list[str] = Field(default_factory=list)
+    batchRefs: list[str] = Field(default_factory=list)
+    status: EvidenceBatchStatus = "ready"
+
+
+class EvidenceMissingSource(BaseModel):
+    nodeId: Optional[str] = None
+    packageNodeId: Optional[str] = None
+    internalNodeId: Optional[str] = None
+    sourceGroup: Optional[str] = None
+    site: Optional[str] = None
+    command: Optional[str] = None
+    reason: Optional[str] = None
+    code: Optional[str] = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvidenceAnswerSummary(BaseModel):
+    summaryId: str = Field(..., min_length=1)
+    title: str = Field(..., min_length=1)
+    text: str
+    clusterRefs: list[str] = Field(default_factory=list)
+    batchRefs: list[str] = Field(default_factory=list)
+    confidence: Optional[float] = Field(None, ge=0, le=1)
+    generatedAt: Optional[str] = None
+
+
+class EvidenceConflict(BaseModel):
+    conflictId: str = Field(..., min_length=1)
+    kind: Optional[str] = None
+    description: Optional[str] = None
+    batchRefs: list[str] = Field(default_factory=list)
+    clusterRefs: list[str] = Field(default_factory=list)
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvidenceNodeProjection(BaseModel):
+    nodeId: str = Field(..., min_length=1)
+    packageNodeId: Optional[str] = None
+    internalNodeId: Optional[str] = None
+    sourceGroup: Optional[str] = None
+    status: Optional[str] = None
+    itemCount: int = Field(0, ge=0)
+    batchRefs: list[str] = Field(default_factory=list)
+    blockReasons: list[str] = Field(default_factory=list)
+
+
+class EvidenceArtifactRef(BaseModel):
+    kind: str = Field(..., min_length=1)
+    uri: str = Field(..., min_length=1)
+    nodeId: Optional[str] = None
+    batchId: Optional[str] = None
+    label: Optional[str] = None
+
+
+class EvidenceProjectionResponse(BaseModel):
+    runId: str = Field(..., min_length=1)
+    status: str = Field(..., min_length=1)
+    valid: bool
+    nodes: list[EvidenceNodeProjection] = Field(default_factory=list)
+    clusters: list[EvidenceCluster] = Field(default_factory=list)
+    missingSources: list[EvidenceMissingSource] = Field(default_factory=list)
+    summaries: list[EvidenceAnswerSummary] = Field(default_factory=list)
+    conflicts: list[EvidenceConflict] = Field(default_factory=list)
+    artifacts: list[EvidenceArtifactRef] = Field(default_factory=list)
+    batches: list[EvidenceBatchSummary] = Field(default_factory=list)

--- a/backend/schemas/workflow.py
+++ b/backend/schemas/workflow.py
@@ -497,6 +497,9 @@ class WorkflowOpenCLIHDATraceDispatch(BaseModel):
     command: str
     args: dict[str, Any] = Field(default_factory=dict)
     iii: dict[str, Any]
+    workerSlotId: Optional[str] = None
+    profileBindingId: Optional[str] = None
+    sessionSnapshotId: Optional[str] = None
 
 
 class WorkflowOpenCLIHDATraceResponse(BaseModel):
@@ -541,6 +544,27 @@ class WorkflowRunBlockReason(BaseModel):
     message: str = Field(..., min_length=1)
     source: Optional[str] = None
     details: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkflowRuntimeResourceRequirement(BaseModel):
+    nodeId: str = Field(..., min_length=1)
+    sourceGroup: str = Field(..., min_length=1)
+    site: str = Field(..., min_length=1)
+    mutationMode: Literal["read", "write"]
+    requestedCapability: str = Field(..., min_length=1)
+    adapterNodeId: Optional[str] = None
+
+
+class WorkflowRuntimeResourceResolution(BaseModel):
+    status: Literal["resolved", "blocked"]
+    adapterNodeId: Optional[str] = None
+    command: Optional[str] = None
+    workerSlotId: Optional[str] = None
+    profileBindingId: Optional[str] = None
+    sessionSnapshotId: Optional[str] = None
+    lockId: Optional[str] = None
+    concurrencyLimit: Optional[int] = Field(default=None, ge=1)
+    blockReason: Optional[WorkflowRunBlockReason] = None
 
 
 class WorkflowRunBatchReference(BaseModel):

--- a/backend/services/browser_service.py
+++ b/backend/services/browser_service.py
@@ -1,9 +1,16 @@
-from typing import Optional
+from __future__ import annotations
+
+import uuid
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.models.browser import BrowserBinding
+from backend.models.browser import (
+    BrowserBinding,
+    ProfileBinding,
+    ProfileLock,
+    SessionSnapshot,
+)
 
 
 async def list_bindings(session: AsyncSession) -> list[BrowserBinding]:
@@ -11,11 +18,11 @@ async def list_bindings(session: AsyncSession) -> list[BrowserBinding]:
     return list(result.scalars().all())
 
 
-async def get_binding(session: AsyncSession, binding_id: str) -> Optional[BrowserBinding]:
+async def get_binding(session: AsyncSession, binding_id: str) -> BrowserBinding | None:
     return await session.get(BrowserBinding, binding_id)
 
 
-async def get_binding_by_site(session: AsyncSession, site: str) -> Optional[BrowserBinding]:
+async def get_binding_by_site(session: AsyncSession, site: str) -> BrowserBinding | None:
     result = await session.execute(
         select(BrowserBinding).where(BrowserBinding.site == site)
     )
@@ -30,6 +37,93 @@ async def create_binding(
     await session.flush()
     await session.refresh(binding)
     return binding
+
+
+async def create_profile_binding(
+    session: AsyncSession,
+    profile_id: str,
+    site: str,
+    browser_endpoint: str,
+    mutation_mode: str = "read",
+    notes: str | None = None,
+) -> ProfileBinding:
+    """Create a saved profile binding without storing cookie material."""
+    binding = ProfileBinding(
+        profile_id=profile_id,
+        site=site,
+        browser_endpoint=browser_endpoint,
+        mutation_mode=mutation_mode,
+        notes=notes,
+    )
+    session.add(binding)
+    await session.flush()
+    await session.refresh(binding)
+    return binding
+
+
+async def get_profile_binding_by_site(
+    session: AsyncSession, site: str
+) -> ProfileBinding | None:
+    result = await session.execute(
+        select(ProfileBinding).where(ProfileBinding.site == site, ProfileBinding.active.is_(True))
+    )
+    return result.scalar_one_or_none()
+
+
+async def publish_session_snapshot(
+    session: AsyncSession,
+    profile_binding_id: str,
+    blob_uri: str | None = None,
+) -> SessionSnapshot:
+    """Publish a new immutable snapshot reference for read-only workers."""
+    snapshot = SessionSnapshot(
+        profile_binding_id=profile_binding_id,
+        snapshot_id=str(uuid.uuid4()),
+        blob_uri=blob_uri,
+    )
+    session.add(snapshot)
+    await session.flush()
+    await session.refresh(snapshot)
+    return snapshot
+
+
+async def get_latest_session_snapshot(
+    session: AsyncSession, profile_binding_id: str
+) -> SessionSnapshot | None:
+    result = await session.execute(
+        select(SessionSnapshot)
+        .where(SessionSnapshot.profile_binding_id == profile_binding_id)
+        .order_by(SessionSnapshot.created_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def acquire_profile_lock(
+    session: AsyncSession,
+    profile_binding_id: str,
+    worker_slot_id: str,
+    lock_token: str,
+) -> ProfileLock | None:
+    """Create an exclusive profile lock; uniqueness makes contention safe."""
+    lock = ProfileLock(
+        profile_binding_id=profile_binding_id,
+        worker_slot_id=worker_slot_id,
+        lock_token=lock_token,
+    )
+    session.add(lock)
+    try:
+        await session.flush()
+    except Exception:
+        await session.rollback()
+        return None
+    await session.refresh(lock)
+    return lock
+
+
+async def release_profile_lock(session: AsyncSession, lock_token: str) -> bool:
+    result = await session.execute(delete(ProfileLock).where(ProfileLock.lock_token == lock_token))
+    return bool(result.rowcount)
 
 
 async def delete_binding(session: AsyncSession, binding_id: str) -> bool:

--- a/backend/services/evidence_service.py
+++ b/backend/services/evidence_service.py
@@ -1,0 +1,608 @@
+"""Read-only EvidenceBatch projection service.
+
+Projects batch, cluster, summary, missing-source, and conflict references from
+the persisted workflow run state. The service does not dispatch workers,
+mutate state, or stream raw records; it reads already-persisted run
+projections and node events and returns reference-style payloads.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.schemas.evidence import (
+    EvidenceAnswerSummary,
+    EvidenceArtifactRef,
+    EvidenceBatchDetailResponse,
+    EvidenceBatchListResponse,
+    EvidenceBatchSourceCoverage,
+    EvidenceBatchSummary,
+    EvidenceCluster,
+    EvidenceConflict,
+    EvidenceMissingSource,
+    EvidenceNodeProjection,
+    EvidenceProjectionResponse,
+    WorkflowProjectionInclude,
+)
+from backend.schemas.workflow import (
+    WorkflowNodeRunEvent,
+    WorkflowRunBatchReference,
+    WorkflowRunProjection,
+)
+from backend.workflow.opencli_hda_tracer import (
+    get_workflow_run_projection,
+    list_workflow_run_events,
+)
+
+_ALLOWED_INCLUDES: set[str] = {
+    "clusters",
+    "missingSources",
+    "summaries",
+    "conflicts",
+}
+
+_DEFAULT_PAGE_SIZE = 50
+_MAX_PAGE_SIZE = 200
+
+
+class EvidenceBatchNotFoundError(Exception):
+    """Raised when a requested batch id is not present for the run."""
+
+
+class EvidenceRunNotFoundError(Exception):
+    """Raised when the requested workflow run id is unknown."""
+
+
+class EvidenceUnsupportedIncludeError(Exception):
+    """Raised when an unsupported include value is requested."""
+
+
+async def list_evidence_batches(
+    run_id: str,
+    *,
+    node_id: str | None = None,
+    source_group: str | None = None,
+    cursor: str | None = None,
+    limit: int | None = None,
+    session: AsyncSession | None = None,
+) -> EvidenceBatchListResponse:
+    """List evidence batch summaries for a workflow run with cursor pagination.
+
+    The cursor is the ``batchId`` of the last item from the previous page.
+    Pagination is offset-free so the result stays stable as new batches arrive.
+    """
+
+    projection, events = await _load_run(run_id, session=session)
+    page_size = _clamp_limit(limit)
+    batches = _project_batches(projection, events)
+    filtered = _filter_batches(batches, node_id=node_id, source_group=source_group)
+    start_index = _resolve_cursor(filtered, cursor)
+    page = filtered[start_index : start_index + page_size]
+    more_available = start_index + page_size < len(filtered)
+    next_cursor = page[-1].batchId if len(page) == page_size and more_available else None
+    return EvidenceBatchListResponse(runId=run_id, batches=page, nextCursor=next_cursor)
+
+
+async def get_evidence_batch(
+    run_id: str,
+    batch_id: str,
+    *,
+    session: AsyncSession | None = None,
+) -> EvidenceBatchDetailResponse:
+    """Return the detail projection for a single evidence batch."""
+
+    projection, events = await _load_run(run_id, session=session)
+    batches = _project_batches(projection, events)
+    match = next((batch for batch in batches if batch.batchId == batch_id), None)
+    if match is None:
+        raise EvidenceBatchNotFoundError(
+            f"Evidence batch {batch_id} not found for run {run_id}"
+        )
+
+    coverage = _source_coverage_for_batch(match, projection, events)
+    return EvidenceBatchDetailResponse(
+        runId=run_id,
+        batch=match,
+        manifestUri=match.manifestUri,
+        odpRef=match.odpRef,
+        recordCount=match.recordCount,
+        itemCount=match.itemCount,
+        sourceCoverage=coverage,
+    )
+
+
+async def build_run_projection(
+    run_id: str,
+    *,
+    include: Iterable[WorkflowProjectionInclude | str] | None = None,
+    node_id: str | None = None,
+    source_group: str | None = None,
+    session: AsyncSession | None = None,
+) -> EvidenceProjectionResponse:
+    """Build the evidence projection for a workflow run.
+
+    ``include`` selects which optional sections to populate. Requesting an
+    unknown include raises :class:`EvidenceUnsupportedIncludeError`.
+    """
+
+    projection, events = await _load_run(run_id, session=session)
+    requested = list(include) if include else []
+    if any(value not in _ALLOWED_INCLUDES for value in requested):
+        unsupported = [v for v in requested if v not in _ALLOWED_INCLUDES]
+        raise EvidenceUnsupportedIncludeError(
+            f"Unsupported include values: {unsupported}"
+        )
+
+    include_set = set(requested)
+    batches = _project_batches(projection, events)
+    if node_id or source_group:
+        batches = _filter_batches(batches, node_id=node_id, source_group=source_group)
+
+    nodes = _project_node_states(projection, batches)
+    artifacts = _project_artifacts(projection, events)
+    missing_sources = (
+        _project_missing_sources(projection, events) if "missingSources" in include_set else []
+    )
+    clusters = (
+        _project_clusters(projection, events, batches) if "clusters" in include_set else []
+    )
+    summaries = (
+        _project_summaries(projection, batches) if "summaries" in include_set else []
+    )
+    conflicts = (
+        _project_conflicts(projection, events, batches) if "conflicts" in include_set else []
+    )
+
+    return EvidenceProjectionResponse(
+        runId=run_id,
+        status=projection.status,
+        valid=projection.valid,
+        nodes=nodes,
+        clusters=clusters,
+        missingSources=missing_sources,
+        summaries=summaries,
+        conflicts=conflicts,
+        artifacts=artifacts,
+        batches=batches,
+    )
+
+
+async def _load_run(
+    run_id: str,
+    *,
+    session: AsyncSession | None,
+) -> tuple[WorkflowRunProjection, list[WorkflowNodeRunEvent]]:
+    projection = await get_workflow_run_projection(run_id, session=session)
+    if projection is None:
+        raise EvidenceRunNotFoundError(f"Workflow run {run_id} not found")
+    events = await list_workflow_run_events(run_id, session=session)
+    if events is None:
+        raise EvidenceRunNotFoundError(f"Workflow run {run_id} not found")
+    return projection, events
+
+
+def _project_batches(
+    projection: WorkflowRunProjection,
+    events: list[WorkflowNodeRunEvent],
+) -> list[EvidenceBatchSummary]:
+    """Project batch summaries from the run projection and node events.
+
+    Batches are deduplicated by ``batchId`` and ordered by first observation.
+    The persisted run projection may already carry per-node batch refs in
+    ``nodeStates.batches``; we merge those with any ``batch_ready`` events to
+    capture both declarative and runtime-observed batches.
+    """
+
+    seen: dict[str, EvidenceBatchSummary] = {}
+    ordered: list[str] = []
+
+    for state in projection.nodeStates:
+        for batch in state.batches:
+            if batch.batchId in seen:
+                continue
+            seen[batch.batchId] = _summary_from_batch(
+                batch, state.nodeId, state.packageNodeId, projection.runId
+            )
+            ordered.append(batch.batchId)
+
+    for event in events:
+        if event.eventType != "batch_ready" or event.batch is None:
+            continue
+        batch = event.batch
+        if batch.batchId in seen:
+            existing = seen[batch.batchId]
+            updates: dict[str, Any] = {}
+            if existing.sourceGroup is None and batch.sourceGroup:
+                updates["sourceGroup"] = batch.sourceGroup
+            if existing.adapterTaskId is None and batch.adapterTaskId:
+                updates["adapterTaskId"] = batch.adapterTaskId
+            if existing.traceId is None and event.traceId:
+                updates["traceId"] = event.traceId
+            if existing.packageNodeId is None and event.packageNodeId:
+                updates["packageNodeId"] = event.packageNodeId
+            if existing.internalNodeId is None and event.internalNodeId:
+                updates["internalNodeId"] = event.internalNodeId
+            if existing.manifestUri is None and batch.manifestUri:
+                updates["manifestUri"] = batch.manifestUri
+            if existing.odpRef is None and batch.odpRef:
+                updates["odpRef"] = batch.odpRef
+            if updates:
+                seen[batch.batchId] = existing.model_copy(update=updates)
+            continue
+        seen[batch.batchId] = EvidenceBatchSummary(
+            runId=event.workflowRunId,
+            nodeId=event.nodeId,
+            packageNodeId=event.packageNodeId,
+            internalNodeId=event.internalNodeId,
+            sourceGroup=batch.sourceGroup or event.sourceGroup,
+            adapterTaskId=batch.adapterTaskId,
+            traceId=event.traceId,
+            batchId=batch.batchId,
+            manifestUri=batch.manifestUri,
+            odpRef=batch.odpRef,
+            itemCount=batch.itemCount,
+            recordCount=batch.recordCount,
+            status=_batch_status(event.nodeId, projection, batch.batchId),
+            createdAt=event.createdAt,
+        )
+        ordered.append(batch.batchId)
+
+    return [seen[batch_id] for batch_id in ordered]
+
+
+def _summary_from_batch(
+    batch: WorkflowRunBatchReference,
+    node_id: str,
+    package_node_id: str | None,
+    run_id: str,
+) -> EvidenceBatchSummary:
+    return EvidenceBatchSummary(
+        runId=run_id,
+        nodeId=node_id,
+        packageNodeId=package_node_id,
+        internalNodeId=None,
+        sourceGroup=batch.sourceGroup,
+        adapterTaskId=batch.adapterTaskId,
+        traceId=None,
+        batchId=batch.batchId,
+        manifestUri=batch.manifestUri,
+        odpRef=batch.odpRef,
+        itemCount=batch.itemCount,
+        recordCount=batch.recordCount,
+        status="ready",
+    )
+
+
+def _batch_status(
+    node_id: str,
+    projection: WorkflowRunProjection,
+    batch_id: str,
+) -> str:
+    state = next((state for state in projection.nodeStates if state.nodeId == node_id), None)
+    if state is None:
+        return "ready"
+    if any(reason.code for reason in state.blockReasons):
+        return "blocked"
+    if state.status == "failed":
+        return "failed"
+    if state.status in {"completed"}:
+        return "ingested"
+    if state.status == "partial":
+        return "partial"
+    return "ready"
+
+
+def _filter_batches(
+    batches: list[EvidenceBatchSummary],
+    *,
+    node_id: str | None,
+    source_group: str | None,
+) -> list[EvidenceBatchSummary]:
+    filtered = list(batches)
+    if node_id:
+        filtered = [batch for batch in filtered if batch.nodeId == node_id]
+    if source_group:
+        filtered = [batch for batch in filtered if batch.sourceGroup == source_group]
+    return filtered
+
+
+def _resolve_cursor(batches: list[EvidenceBatchSummary], cursor: str | None) -> int:
+    if cursor is None:
+        return 0
+    for index, batch in enumerate(batches):
+        if batch.batchId == cursor:
+            return index + 1
+    return 0
+
+
+def _clamp_limit(limit: int | None) -> int:
+    if limit is None or limit <= 0:
+        return _DEFAULT_PAGE_SIZE
+    return min(limit, _MAX_PAGE_SIZE)
+
+
+def _source_coverage_for_batch(
+    batch: EvidenceBatchSummary,
+    projection: WorkflowRunProjection,
+    events: list[WorkflowNodeRunEvent],
+) -> list[EvidenceBatchSourceCoverage]:
+    """Build a per-source coverage summary for a single batch.
+
+    Coverage is derived from ``batch_ready`` events that share the batch id and
+    the run projection node state.
+    """
+
+    coverage_by_group: dict[str, EvidenceBatchSourceCoverage] = {}
+    site_by_group: dict[str, str | None] = {}
+    command_by_group: dict[str, str | None] = {}
+    for event in events:
+        if event.eventType != "batch_ready" or event.batch is None:
+            continue
+        if event.batch.batchId != batch.batchId:
+            continue
+        group = batch.sourceGroup or event.sourceGroup
+        if group is None:
+            continue
+        site, command = _extract_site_command(event)
+        site_by_group[group] = site
+        command_by_group[group] = command
+        if group not in coverage_by_group:
+            coverage_by_group[group] = EvidenceBatchSourceCoverage(
+                sourceGroup=group,
+                site=site,
+                command=command,
+                itemCount=event.batch.itemCount,
+                recordCount=event.batch.recordCount,
+                status=_batch_status(event.nodeId, projection, batch.batchId),
+            )
+        else:
+            existing = coverage_by_group[group]
+            coverage_by_group[group] = existing.model_copy(
+                update={
+                    "itemCount": existing.itemCount + event.batch.itemCount,
+                    "recordCount": existing.recordCount + event.batch.recordCount,
+                }
+            )
+
+    if not coverage_by_group and batch.sourceGroup:
+        coverage_by_group[batch.sourceGroup] = EvidenceBatchSourceCoverage(
+            sourceGroup=batch.sourceGroup,
+            site=None,
+            command=None,
+            itemCount=batch.itemCount,
+            recordCount=batch.recordCount,
+            status=batch.status,
+        )
+    return list(coverage_by_group.values())
+
+
+def _extract_site_command(event: WorkflowNodeRunEvent) -> tuple[str | None, str | None]:
+    details = event.details if isinstance(event.details, dict) else {}
+    site = details.get("site") if isinstance(details, dict) else None
+    command = details.get("command") if isinstance(details, dict) else None
+    if not site and isinstance(details.get("function_id"), str):
+        site = None
+    return _safe_string(site), _safe_string(command)
+
+
+def _project_node_states(
+    projection: WorkflowRunProjection,
+    batches: list[EvidenceBatchSummary],
+) -> list[EvidenceNodeProjection]:
+    batch_by_node: dict[str, list[str]] = {}
+    for batch in batches:
+        batch_by_node.setdefault(batch.nodeId, []).append(batch.batchId)
+
+    nodes: list[EvidenceNodeProjection] = []
+    for state in projection.nodeStates:
+        nodes.append(
+            EvidenceNodeProjection(
+                nodeId=state.nodeId,
+                packageNodeId=state.packageNodeId,
+                internalNodeId=state.internalNodeId,
+                sourceGroup=state.sourceGroups[0] if state.sourceGroups else None,
+                status=state.status,
+                itemCount=sum(
+                    batch.itemCount
+                    for batch in batches
+                    if batch.nodeId == state.nodeId
+                ),
+                batchRefs=batch_by_node.get(state.nodeId, []),
+                blockReasons=[reason.code for reason in state.blockReasons if reason.code],
+            )
+        )
+    return nodes
+
+
+def _project_artifacts(
+    projection: WorkflowRunProjection,
+    events: list[WorkflowNodeRunEvent],
+) -> list[EvidenceArtifactRef]:
+    artifacts: list[EvidenceArtifactRef] = []
+    seen: set[str] = set()
+    for event in events:
+        if not event.batch or not event.batch.manifestUri:
+            continue
+        if event.batch.manifestUri in seen:
+            continue
+        seen.add(event.batch.manifestUri)
+        artifacts.append(
+            EvidenceArtifactRef(
+                kind="manifest",
+                uri=event.batch.manifestUri,
+                nodeId=event.nodeId,
+                batchId=event.batch.batchId,
+                label=event.batch.sourceGroup,
+            )
+        )
+    if projection.traceId:
+        artifacts.append(
+            EvidenceArtifactRef(
+                kind="trace",
+                uri=f"/api/v1/workflows/runs/{projection.runId}/trace",
+                label=projection.traceId,
+            )
+        )
+    return artifacts
+
+
+def _project_missing_sources(
+    projection: WorkflowRunProjection,
+    events: list[WorkflowNodeRunEvent],
+) -> list[EvidenceMissingSource]:
+    """Project missing-source descriptors from blocked node events."""
+
+    reasons_by_node: dict[str, EvidenceMissingSource] = {}
+    for state in projection.nodeStates:
+        if not state.blockReasons:
+            continue
+        for reason in state.blockReasons:
+            key = state.nodeId
+            if key in reasons_by_node:
+                continue
+            reasons_by_node[key] = EvidenceMissingSource(
+                nodeId=state.nodeId,
+                packageNodeId=state.packageNodeId,
+                internalNodeId=state.internalNodeId,
+                sourceGroup=state.sourceGroups[0] if state.sourceGroups else None,
+                reason=reason.message,
+                code=reason.code,
+                details=dict(reason.details or {}),
+            )
+
+    for event in events:
+        if event.eventType not in {"blocked", "failed"} or event.blockReason is None:
+            continue
+        key = event.nodeId
+        if key in reasons_by_node:
+            continue
+        reasons_by_node[key] = EvidenceMissingSource(
+            nodeId=event.nodeId,
+            packageNodeId=event.packageNodeId,
+            internalNodeId=event.internalNodeId,
+            sourceGroup=event.sourceGroup,
+            reason=event.blockReason.message,
+            code=event.blockReason.code,
+            details=dict(event.blockReason.details or {}),
+        )
+    return list(reasons_by_node.values())
+
+
+def _project_clusters(
+    projection: WorkflowRunProjection,
+    events: list[WorkflowNodeRunEvent],
+    batches: list[EvidenceBatchSummary],
+) -> list[EvidenceCluster]:
+    """Project canonical-evidence clusters from accepted-record lineage.
+
+    Clusters group records by ``sourceGroup`` to give consumers an inspectable
+    summary that links back to the originating batch refs. They are projected
+    deterministically and require no extra schema state.
+    """
+
+    by_source_group: dict[str, EvidenceCluster] = {}
+    for state in projection.nodeStates:
+        groups = list(state.sourceGroups or [])
+        if not groups:
+            for event in events:
+                if event.nodeId == state.nodeId and event.sourceGroup:
+                    groups.append(event.sourceGroup)
+        for group in groups:
+            if group in by_source_group:
+                continue
+            cluster_id = _stable_id("cluster", projection.runId, group)
+            batch_refs = [batch.batchId for batch in batches if batch.sourceGroup == group]
+            by_source_group[group] = EvidenceCluster(
+                clusterId=cluster_id,
+                label=group,
+                sourceGroups=[group],
+                batchRefs=batch_refs,
+                status="ready" if state.status == "completed" else "partial",
+            )
+    return list(by_source_group.values())
+
+
+def _project_summaries(
+    projection: WorkflowRunProjection,
+    batches: list[EvidenceBatchSummary],
+) -> list[EvidenceAnswerSummary]:
+    """Project run-level answer summaries derived from the projection state."""
+
+    if projection.status not in {"completed", "partial"}:
+        return []
+    summary_id = _stable_id("summary", projection.runId, projection.status)
+    total_items = sum(batch.itemCount for batch in batches)
+    total_records = sum(batch.recordCount for batch in batches)
+    batch_refs = [batch.batchId for batch in batches]
+    return [
+        EvidenceAnswerSummary(
+            summaryId=summary_id,
+            title=f"Workflow {projection.workflowId} projection summary",
+            text=(
+                f"Run {projection.runId} collected {total_items} items across "
+                f"{len(batches)} batches ({total_records} records accepted)."
+            ),
+            clusterRefs=[],
+            batchRefs=batch_refs,
+            confidence=None,
+            generatedAt=projection.updatedAt,
+        )
+    ]
+
+
+def _project_conflicts(
+    projection: WorkflowRunProjection,
+    events: list[WorkflowNodeRunEvent],
+    batches: list[EvidenceBatchSummary],
+) -> list[EvidenceConflict]:
+    """Project structural conflicts from blocked or failed nodes.
+
+    Each blocked/failed node contributes a conflict descriptor so consumers can
+    link missing sources and runtime blocks back to the originating batch
+    references without losing provenance.
+    """
+
+    conflicts: list[EvidenceConflict] = []
+    for state in projection.nodeStates:
+        if state.status not in {"blocked", "failed"} or not state.blockReasons:
+            continue
+        for reason in state.blockReasons:
+            conflict_id = _stable_id("conflict", projection.runId, state.nodeId, reason.code)
+            batch_refs = [batch.batchId for batch in batches if batch.nodeId == state.nodeId]
+            kind = (reason.details or {}).get("bindingId") if reason.details else None
+            conflicts.append(
+                EvidenceConflict(
+                    conflictId=conflict_id,
+                    kind=kind,
+                    description=reason.message,
+                    batchRefs=batch_refs,
+                    clusterRefs=[],
+                    details=dict(reason.details or {}),
+                )
+            )
+    return conflicts
+
+
+def _safe_string(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha1("/".join((prefix, *parts)).encode("utf-8")).hexdigest()
+    return f"{prefix}-{digest[:16]}"
+
+
+__all__ = [
+    "EvidenceBatchNotFoundError",
+    "EvidenceRunNotFoundError",
+    "EvidenceUnsupportedIncludeError",
+    "build_run_projection",
+    "get_evidence_batch",
+    "list_evidence_batches",
+]

--- a/backend/workflow/block_reasons.py
+++ b/backend/workflow/block_reasons.py
@@ -20,6 +20,13 @@ MISSING_RUNTIME_BINDING = "missing_runtime_binding"
 MISSING_RUNTIME_IO_CONTRACT = "missing_runtime_io_contract"
 MISSING_RUNTIME_PARAMETER = "missing_runtime_parameter"
 MISSING_SOURCE_CREDENTIAL = "missing_source_credential"
+MISSING_ADAPTER_RESOURCE = "missing_adapter_resource"
+MISSING_OPENCLI_COMMAND = "missing_opencli_command"
+MISSING_PROFILE_BINDING = "missing_profile_binding"
+MISSING_SESSION_SNAPSHOT = "missing_session_snapshot"
+MISSING_WORKER_CAPACITY = "missing_worker_capacity"
+PROFILE_LOCK_CONTENDED = "profile_lock_contended"
+MUTATION_MODE_UNSUPPORTED = "mutation_mode_unsupported"
 MISSING_TOOL_CAPABILITY_BINDING = "missing_tool_capability_binding"
 MISSING_TURBOPUSH_CONTENT_TYPE = "missing_turbopush_content_type"
 MISSING_TURBOPUSH_SERVICE = "missing_turbopush_service"
@@ -95,6 +102,48 @@ WORKFLOW_BLOCK_REASON_TAXONOMY: dict[str, WorkflowBlockReasonDefinition] = {
         volatile_fields=("message",),
         description="Tool-capability node has no registered backend tool binding.",
     ),
+    MISSING_ADAPTER_RESOURCE: WorkflowBlockReasonDefinition(
+        code=MISSING_ADAPTER_RESOURCE,
+        category="missing_runtime_resource",
+        stable_fields=("code", "source", "details.adapterNodeId"),
+        description="OpenCLI adapter capability is unavailable.",
+    ),
+    MISSING_OPENCLI_COMMAND: WorkflowBlockReasonDefinition(
+        code=MISSING_OPENCLI_COMMAND,
+        category="missing_runtime_resource",
+        stable_fields=("code", "source", "details.site"),
+        description="The OpenCLI command could not be resolved.",
+    ),
+    MISSING_PROFILE_BINDING: WorkflowBlockReasonDefinition(
+        code=MISSING_PROFILE_BINDING,
+        category="missing_runtime_resource",
+        stable_fields=("code", "source", "details.site"),
+        description="Browser execution requires a profile binding that is unavailable.",
+    ),
+    MISSING_SESSION_SNAPSHOT: WorkflowBlockReasonDefinition(
+        code=MISSING_SESSION_SNAPSHOT,
+        category="missing_runtime_resource",
+        stable_fields=("code", "source", "details.site"),
+        description="Read-only browser fanout requires a shareable session snapshot.",
+    ),
+    MISSING_WORKER_CAPACITY: WorkflowBlockReasonDefinition(
+        code=MISSING_WORKER_CAPACITY,
+        category="missing_runtime_resource",
+        stable_fields=("code", "source", "details.requestedCapability"),
+        description="No worker slot currently satisfies the runtime requirement.",
+    ),
+    PROFILE_LOCK_CONTENDED: WorkflowBlockReasonDefinition(
+        code=PROFILE_LOCK_CONTENDED,
+        category="missing_runtime_resource",
+        stable_fields=("code", "source", "details.site"),
+        description="A mutating browser task cannot acquire the profile lock.",
+    ),
+    MUTATION_MODE_UNSUPPORTED: WorkflowBlockReasonDefinition(
+        code=MUTATION_MODE_UNSUPPORTED,
+        category="missing_runtime_resource",
+        stable_fields=("code", "source", "details.site"),
+        description="The requested browser mutation mode is unsupported.",
+    ),
     MISSING_TURBOPUSH_CONTENT_TYPE: WorkflowBlockReasonDefinition(
         code=MISSING_TURBOPUSH_CONTENT_TYPE,
         category="missing_config",
@@ -136,6 +185,13 @@ __all__ = [
     "MISSING_RUNTIME_IO_CONTRACT",
     "MISSING_RUNTIME_PARAMETER",
     "MISSING_SOURCE_CREDENTIAL",
+    "MISSING_ADAPTER_RESOURCE",
+    "MISSING_OPENCLI_COMMAND",
+    "MISSING_PROFILE_BINDING",
+    "MISSING_SESSION_SNAPSHOT",
+    "MISSING_WORKER_CAPACITY",
+    "PROFILE_LOCK_CONTENDED",
+    "MUTATION_MODE_UNSUPPORTED",
     "MISSING_TOOL_CAPABILITY_BINDING",
     "MISSING_TURBOPUSH_CONTENT_TYPE",
     "MISSING_TURBOPUSH_SERVICE",

--- a/backend/workflow/capability_projection.py
+++ b/backend/workflow/capability_projection.py
@@ -7,7 +7,7 @@ visible nodes are blocked until a real binding is added.
 
 from __future__ import annotations
 
-from backend.channels.registry import list_channel_types
+from backend.channels.registry import get_channel, list_channel_types
 from backend.notifiers.registry import list_notifier_types
 from backend.schemas.workflow import (
     WorkflowCapabilitiesResponse,
@@ -30,12 +30,85 @@ from backend.workflow.runtime_registry import (
     RECORD_ACCEPTANCE_BINDING_ID,
     RECORD_SINK_BINDING_ID,
     SCHEDULE_TRIGGER_BINDING_ID,
+    SOURCE_FETCH_BINDING_ID,
     SOURCE_POOL_BINDING_ID,
     TURBOPUSH_BINDING_ID,
     WEBHOOK_NOTIFY_BINDING_ID,
 )
 from backend.workflow.tool_capabilities import list_workflow_tool_capabilities
 from backend.workflow.turbopush_runtime import TURBOPUSH_PROVIDER
+
+CANVAS_SOURCE_CHANNEL_TYPES = (
+    "opencli",
+    "web_scraper",
+    "api",
+    "rss",
+    "cli",
+    "skill",
+    "crawl4ai",
+)
+
+CHANNEL_LABELS = {
+    "opencli": "OpenCLI",
+    "web_scraper": "Web Scraper",
+    "api": "API",
+    "rss": "RSS",
+    "cli": "CLI",
+    "skill": "Skill",
+    "crawl4ai": "Crawl4AI",
+}
+
+CHANNEL_REQUIRED_CONFIG = {
+    "opencli": ["site", "command"],
+    "web_scraper": ["url", "selectors"],
+    "api": ["base_url", "endpoint"],
+    "rss": ["feed_url"],
+    "cli": ["binary", "command"],
+    "skill": ["skill_md_or_skill_id_or_domain_capability"],
+    "crawl4ai": ["url", "selectors_or_instruction"],
+}
+
+CHANNEL_DEFAULT_PARAMS: dict[str, dict[str, object]] = {
+    "opencli": {
+        "site": "bilibili",
+        "command": "search",
+        "sourceGroup": "video",
+        "args": {"keyword": "ai"},
+    },
+    "web_scraper": {"url": "", "selectors": {}},
+    "api": {"base_url": "", "endpoint": "", "method": "GET"},
+    "rss": {"feed_url": "", "max_entries": 50},
+    "cli": {"binary": "", "command": [], "output_format": "json"},
+    "skill": {"task": ""},
+    "crawl4ai": {"url": "", "selectors": {}, "instruction": ""},
+}
+
+CHANNEL_BLOCKED_REASONS = {
+    "web_scraper": (
+        "The Web Scraper DataSource channel is implemented, but Canvas runs still "
+        "need a live source executor plus a configured URL and CSS selectors."
+    ),
+    "api": (
+        "The API DataSource channel is implemented, but Canvas runs still need a "
+        "live source executor plus a configured base URL and endpoint."
+    ),
+    "rss": (
+        "The RSS DataSource channel is implemented, but Canvas runs still need a "
+        "live source executor plus a configured feed URL."
+    ),
+    "cli": (
+        "The CLI DataSource channel is implemented, but Canvas runs still need a "
+        "live source executor plus an operator-allowlisted binary and command."
+    ),
+    "skill": (
+        "The Skill DataSource channel is implemented, but Canvas runs still need a "
+        "live source executor plus a saved skill binding and browser session resource."
+    ),
+    "crawl4ai": (
+        "The Crawl4AI DataSource channel is implemented, but Canvas runs still need "
+        "a live source executor plus a URL and selectors or extraction instruction."
+    ),
+}
 
 
 def build_workflow_capabilities() -> WorkflowCapabilitiesResponse:
@@ -92,6 +165,13 @@ def _capability(
 
 
 def _catalog_capabilities() -> list[WorkflowRuntimeCapability]:
+    return [
+        *_catalog_base_capabilities(),
+        *_canvas_source_catalog_capabilities(),
+    ]
+
+
+def _catalog_base_capabilities() -> list[WorkflowRuntimeCapability]:
     return [
         _capability(
             id="intelligence.input.collection-need",
@@ -537,6 +617,113 @@ def _catalog_capabilities() -> list[WorkflowRuntimeCapability]:
     ]
 
 
+def _canvas_source_catalog_capabilities() -> list[WorkflowRuntimeCapability]:
+    return [
+        _channel_capability(channel_type, surface="catalog")
+        for channel_type in CANVAS_SOURCE_CHANNEL_TYPES
+    ]
+
+
+def _channel_capability(
+    channel_type: str,
+    *,
+    surface: WorkflowCapabilitySurface = "channel",
+) -> WorkflowRuntimeCapability:
+    channel = get_channel(channel_type)
+    label = CHANNEL_LABELS[channel_type]
+    runtime_binding = OPENCLI_BINDING_ID if channel_type == "opencli" else SOURCE_FETCH_BINDING_ID
+    is_runnable = channel_type == "opencli"
+    missing = (
+        ["canvas_resource_resolution"]
+        if is_runnable
+        else [
+            "live_source_executor",
+            *[f"channel_config.{field}" for field in CHANNEL_REQUIRED_CONFIG[channel_type]],
+        ]
+    )
+    if channel.capabilities.session_affinity:
+        missing.append("browser_session_resource")
+    if channel_type == "cli":
+        missing.append("cli_binary_allowlist")
+
+    return _capability(
+        id=(
+            f"channel.{channel_type}"
+            if surface == "channel"
+            else f"intelligence.source.channel.{channel_type}"
+        ),
+        label=f"{label} Source" if surface == "catalog" else f"{label} channel",
+        surface=surface,
+        status="runnable" if is_runnable else "blocked",
+        backend_available=True,
+        kind="source",
+        capability="fetch",
+        provider=channel_type,
+        channel_type=channel_type,
+        runtime_binding=runtime_binding,
+        reason=(
+            "The workflow runtime registry resolves OpenCLI source/fetch nodes "
+            "to the dedicated OpenCLI collector binding."
+            if is_runnable
+            else CHANNEL_BLOCKED_REASONS[channel_type]
+        ),
+        missing=missing,
+        tags=["channel", "source", channel_type],
+        source=f"backend.channels.{channel_type}_channel",
+        manifest=_channel_manifest(channel_type),
+    )
+
+
+def _channel_manifest(channel_type: str) -> dict[str, object]:
+    channel = get_channel(channel_type)
+    label = CHANNEL_LABELS[channel_type]
+    runtime_binding = OPENCLI_BINDING_ID if channel_type == "opencli" else SOURCE_FETCH_BINDING_ID
+    adapter_id = f"channel-{channel_type}"
+    config = CHANNEL_DEFAULT_PARAMS[channel_type]
+    return {
+        "schema": "capability.source.channel.v1",
+        "ports": {
+            "inputs": [_port("in", "trigger")],
+            "outputs": [_port("items", "items[]")],
+        },
+        "resources": ["saved_data_source", "source_credentials"],
+        "permissions": ["canFetchNetwork"],
+        "runtime": {"binding": runtime_binding},
+        "trace": {"events": ["partial:itemCount", "blocked", "completed"]},
+        "probes": ["channel_registered", "channel_config_valid"],
+        "channel": {
+            "type": channel_type,
+            "capabilities": {
+                "incremental": channel.capabilities.incremental,
+                "paginated": channel.capabilities.paginated,
+                "authKind": channel.capabilities.auth_kind,
+                "sessionAffinity": channel.capabilities.session_affinity,
+                "defaultRate": channel.capabilities.default_rate,
+            },
+            "requiredConfig": CHANNEL_REQUIRED_CONFIG[channel_type],
+        },
+        "canvas": {
+            "node": True,
+            "catalogId": f"intelligence.source.channel.{channel_type}",
+            "idPrefix": f"source-{channel_type.replace('_', '-')}",
+            "label": f"{label} Source",
+            "description": f"Collect items through the backend {label} DataSource channel.",
+            "category": "source",
+            "icon": "Globe",
+            "color": "var(--chart-4)",
+            "keywords": [channel_type, label.lower(), "source", "channel", "fetch"],
+            "adapter": {
+                "id": adapter_id,
+                "type": "source",
+                "provider": channel_type,
+                "mode": "live",
+                "config": {"channel": channel_type, **config},
+            },
+            "params": {"channelType": channel_type, **config},
+        },
+    }
+
+
 def _manifest(
     *,
     schema: str,
@@ -672,49 +859,27 @@ def _primitive_capabilities() -> list[WorkflowRuntimeCapability]:
 
 
 def _channel_capabilities() -> list[WorkflowRuntimeCapability]:
-    rows: list[WorkflowRuntimeCapability] = []
-    for channel_type in sorted(list_channel_types()):
-        if channel_type == "opencli":
-            rows.append(
-                _capability(
-                    id=f"channel.{channel_type}",
-                    label="OpenCLI channel",
-                    surface="channel",
-                    status="runnable",
-                    backend_available=True,
-                    kind="source",
-                    capability="fetch",
-                    provider="opencli",
-                    channel_type=channel_type,
-                    runtime_binding=OPENCLI_BINDING_ID,
-                    reason="The workflow runtime registry resolves OpenCLI "
-                    "source/fetch nodes to this channel.",
-                    missing=["canvas_resource_resolution"],
-                    tags=["channel", "source", "opencli"],
-                    source="backend.channels.opencli_channel",
-                )
-            )
-            continue
-
-        rows.append(
-            _capability(
-                id=f"channel.{channel_type}",
-                label=f"{channel_type} channel",
-                surface="channel",
-                status="blocked",
-                backend_available=True,
-                kind="source",
-                capability="fetch",
-                provider=channel_type,
-                channel_type=channel_type,
-                reason="A real DataSource channel exists, but it has not been "
-                "projected into Canvas source nodes or workflow runtime binding.",
-                missing=["canvas_source_projection", "workflow_runtime_binding"],
-                tags=["channel", "source"],
-                source=f"backend.channels.{channel_type}_channel",
-            )
+    return [
+        _channel_capability(channel_type)
+        if channel_type in CANVAS_SOURCE_CHANNEL_TYPES
+        else _capability(
+            id=f"channel.{channel_type}",
+            label=f"{channel_type} channel",
+            surface="channel",
+            status="blocked",
+            backend_available=True,
+            kind="source",
+            capability="fetch",
+            provider=channel_type,
+            channel_type=channel_type,
+            reason="The registered channel exists outside the seven Canvas source "
+            "projections and has no Canvas source-node contract.",
+            missing=["canvas_source_projection", "workflow_runtime_binding"],
+            tags=["channel", "source"],
+            source=f"backend.channels.{channel_type}_channel",
         )
-    return rows
+        for channel_type in sorted(list_channel_types())
+    ]
 
 
 def _notifier_capabilities() -> list[WorkflowRuntimeCapability]:

--- a/backend/workflow/opencli_hda_tracer.py
+++ b/backend/workflow/opencli_hda_tracer.py
@@ -65,6 +65,7 @@ from backend.workflow.runtime_registry import (
     SOURCE_FETCH_BINDING_ID,
     WEBHOOK_NOTIFY_BINDING_ID,
 )
+from backend.workflow.runtime_resources import resolve_runtime_resources
 from backend.workflow.turbopush_executor import (
     TurboPushPublishError,
     execute_turbopush_publish,
@@ -487,9 +488,49 @@ async def start_workflow_run(
             node,
             session=session,
         )
+        resource_requirement, resource_resolution = resolve_runtime_resources(
+            dispatch,
+            node,
+            fleet_match,
+        )
+        resource_details = {
+            "resourceRequirement": resource_requirement.model_dump(
+                mode="json",
+                exclude_none=True,
+            ),
+            "resourceResolution": resource_resolution.model_dump(
+                mode="json",
+                exclude_none=True,
+            ),
+        }
         fleet_match_details = _fleet_match_trace_details(fleet_match)
         if fleet_match_details:
             emitter.events[-1].details["fleetMatch"] = fleet_match_details
+        emitter.events[-1].details.update(resource_details)
+
+        if resource_resolution.status == "blocked":
+            reason = resource_resolution.blockReason
+            assert reason is not None
+            emitter.emit(
+                node,
+                "blocked",
+                message=reason.message,
+                block_reason=reason,
+                details=reason.details,
+            )
+            if package_parent_id:
+                blocked_by_package.setdefault(package_parent_id, []).append(reason)
+            outputs_by_node[node.id] = []
+            continue
+
+        resource_id_updates = {
+            "workerSlotId": resource_resolution.workerSlotId,
+            "profileBindingId": resource_resolution.profileBindingId,
+            "sessionSnapshotId": resource_resolution.sessionSnapshotId,
+        }
+        dispatch = dispatch.model_copy(update={
+            key: value for key, value in resource_id_updates.items() if value is not None
+        })
 
         output_items, agent_dispatch_details = await _dispatch_opencli_source_to_fleet(
             dispatch,
@@ -501,6 +542,7 @@ async def start_workflow_run(
         dispatch_trace_details = {
             **({"fleetMatch": fleet_match_details} if fleet_match_details else {}),
             **({"agentDispatch": agent_dispatch_details} if agent_dispatch_details else {}),
+            **resource_details,
         }
         emitter.emit(
             node,

--- a/backend/workflow/runtime_registry.py
+++ b/backend/workflow/runtime_registry.py
@@ -6,7 +6,11 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from backend.schemas.workflow import WorkflowAdapterBinding, WorkflowProjectNode
+from backend.schemas.workflow import (
+    WorkflowAdapterBinding,
+    WorkflowProjectNode,
+    WorkflowRuntimeResourceRequirement,
+)
 from backend.workflow.block_reasons import (
     MISSING_DELIVERY_PROJECTION,
     MISSING_RUNTIME_BINDING,
@@ -168,16 +172,25 @@ def _resolve_opencli_source(
             )
         }
 
-    return {
-        "binding": WorkflowRuntimeBinding(
-            binding_id=OPENCLI_BINDING_ID,
-            runtime="iii",
-            worker=OPENCLI_WORKER,
-            function_id=OPENCLI_FUNCTION_ID,
-            channel="opencli",
-            input={"site": site, "command": command},
-        ).model_dump()
-    }
+    binding = WorkflowRuntimeBinding(
+        binding_id=OPENCLI_BINDING_ID,
+        runtime="iii",
+        worker=OPENCLI_WORKER,
+        function_id=OPENCLI_FUNCTION_ID,
+        channel="opencli",
+        input={"site": site, "command": command},
+    ).model_dump()
+    binding["resource_requirement"] = WorkflowRuntimeResourceRequirement(
+        nodeId=node_id,
+        sourceGroup=_read_string(node.params.get("sourceGroup")) or node_id,
+        site=site,
+        mutationMode=(
+            "write" if _read_string(node.params.get("mutationMode")) == "write" else "read"
+        ),
+        requestedCapability=f"opencli.{site}.{command}",
+        adapterNodeId=adapter.id if adapter else None,
+    ).model_dump()
+    return {"binding": binding}
 
 
 def _resolve_collection_need(node: WorkflowProjectNode, *, node_id: str) -> dict[str, Any]:
@@ -269,6 +282,12 @@ def _resolve_source_fetch_node(
             "provider": provider,
             "channelType": channel_type,
             "dispatch": "runtime_source_binding",
+            "status_anchor": node_id,
+            "result_projection": {
+                "events": "/api/v1/workflows/runs/{run_id}/events/stream",
+                "evidenceBatches": "/api/v1/workflows/runs/{run_id}/evidence-batches",
+                "projection": "/api/v1/workflows/runs/{run_id}/projection",
+            },
         },
     }
 

--- a/backend/workflow/runtime_resources.py
+++ b/backend/workflow/runtime_resources.py
@@ -1,0 +1,420 @@
+"""Resolve browser-worker capacity and profile/session runtime resources."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.browser_pool import get_pool
+from backend.models.browser import (
+    BrowserBinding,
+)
+from backend.models.browser import (
+    ProfileBinding as ProfileBindingRow,
+)
+from backend.models.browser import (
+    SessionSnapshot as SessionSnapshotRow,
+)
+from backend.schemas.workflow import (
+    CompiledWorkflowNode,
+    WorkflowFleetCapabilityMatchResponse,
+    WorkflowOpenCLIHDATraceDispatch,
+    WorkflowRunBlockReason,
+    WorkflowRuntimeResourceRequirement,
+    WorkflowRuntimeResourceResolution,
+)
+from backend.workflow.block_reasons import (
+    MISSING_ADAPTER_RESOURCE,
+    MISSING_OPENCLI_COMMAND,
+    MISSING_PROFILE_BINDING,
+    MISSING_SESSION_SNAPSHOT,
+    MISSING_WORKER_CAPACITY,
+    MUTATION_MODE_UNSUPPORTED,
+    PROFILE_LOCK_CONTENDED,
+)
+from backend.workflow.opencli_adapter_nodes import resolve_opencli_adapter_node
+
+
+@dataclass(frozen=True)
+class ProfileBinding:
+    """A saved site/profile reference shared by browser workers."""
+
+    binding_id: str
+    site: str
+    browser_endpoint: str
+    profile_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionSnapshot:
+    """An immutable, shareable read-only browser session snapshot."""
+
+    snapshot_id: str
+    profile_binding_id: str
+    created_at: datetime
+    blob_uri: str | None = None
+
+
+@dataclass(frozen=True)
+class ProfileLock:
+    """A lease granting one worker exclusive profile mutation access."""
+
+    lock_id: str
+    profile_binding_id: str
+    worker_slot_id: str
+    acquired_at: datetime
+
+
+class ProfileLockManager:
+    """Process-local lock manager used by local browser-worker execution."""
+
+    def __init__(self) -> None:
+        self._locks: dict[str, ProfileLock] = {}
+        self._guard = asyncio.Lock()
+
+    async def acquire(
+        self,
+        profile_binding_id: str,
+        worker_slot_id: str,
+    ) -> ProfileLock | None:
+        async with self._guard:
+            if profile_binding_id in self._locks:
+                return None
+            lock = ProfileLock(
+                lock_id=str(uuid.uuid4()),
+                profile_binding_id=profile_binding_id,
+                worker_slot_id=worker_slot_id,
+                acquired_at=datetime.now(UTC),
+            )
+            self._locks[profile_binding_id] = lock
+            return lock
+
+    async def release(self, lock_id: str) -> bool:
+        async with self._guard:
+            profile_binding_id = next(
+                (
+                    binding_id
+                    for binding_id, lock in self._locks.items()
+                    if lock.lock_id == lock_id
+                ),
+                None,
+            )
+            if profile_binding_id is None:
+                return False
+            del self._locks[profile_binding_id]
+            return True
+
+    def get(self, profile_binding_id: str) -> ProfileLock | None:
+        return self._locks.get(profile_binding_id)
+
+
+class SessionSnapshotStore:
+    """In-memory index for snapshot references shared by read-only workers."""
+
+    def __init__(self) -> None:
+        self._snapshots: dict[str, SessionSnapshot] = {}
+
+    def publish(
+        self,
+        profile_binding_id: str,
+        *,
+        snapshot_id: str | None = None,
+        blob_uri: str | None = None,
+    ) -> SessionSnapshot:
+        snapshot = SessionSnapshot(
+            snapshot_id=snapshot_id or str(uuid.uuid4()),
+            profile_binding_id=profile_binding_id,
+            created_at=datetime.now(UTC),
+            blob_uri=blob_uri,
+        )
+        self._snapshots[profile_binding_id] = snapshot
+        return snapshot
+
+    def get(self, profile_binding_id: str) -> SessionSnapshot | None:
+        return self._snapshots.get(profile_binding_id)
+
+
+profile_locks = ProfileLockManager()
+session_snapshots = SessionSnapshotStore()
+
+
+def resolve_runtime_resources(
+    dispatch: WorkflowOpenCLIHDATraceDispatch,
+    node: CompiledWorkflowNode,
+    match: WorkflowFleetCapabilityMatchResponse | None,
+) -> tuple[WorkflowRuntimeResourceRequirement, WorkflowRuntimeResourceResolution]:
+    """Resolve compiled OpenCLI metadata without exposing profile secrets."""
+    adapter_node_id = _read_string(node.params.get("opencliAdapterNodeId"))
+    adapter_node = resolve_opencli_adapter_node(adapter_node_id) if adapter_node_id else None
+    mutation_mode = "write" if adapter_node and adapter_node.access == "write" else "read"
+    requirement = WorkflowRuntimeResourceRequirement(
+        nodeId=dispatch.nodeId,
+        sourceGroup=dispatch.sourceGroup,
+        site=dispatch.site,
+        mutationMode=mutation_mode,
+        requestedCapability=f"opencli.{dispatch.site}.{dispatch.command or 'unresolved'}",
+        adapterNodeId=adapter_node_id,
+    )
+
+    if not dispatch.command:
+        return requirement, _blocked(
+            MISSING_OPENCLI_COMMAND,
+            "OpenCLI command could not be resolved from runtime metadata.",
+            requirement,
+        )
+    if adapter_node_id and adapter_node is None:
+        return requirement, _blocked(
+            MISSING_ADAPTER_RESOURCE,
+            f'OpenCLI adapter capability "{adapter_node_id}" is not registered.',
+            requirement,
+        )
+    if match is None:
+        return requirement, WorkflowRuntimeResourceResolution(
+            status="resolved",
+            adapterNodeId=adapter_node_id or (node.adapter.id if node.adapter else None),
+            command=dispatch.command,
+            workerSlotId="iii:collector-opencli",
+            concurrencyLimit=1,
+        )
+    if (
+        not adapter_node_id
+        and node.adapter is not None
+        and node.adapter.provider == "opencli"
+        and not match.matched
+    ):
+        return requirement, WorkflowRuntimeResourceResolution(
+            status="resolved",
+            adapterNodeId=node.adapter.id,
+            command=dispatch.command,
+            workerSlotId="iii:collector-opencli",
+            concurrencyLimit=1,
+        )
+    if not match.matched or match.selected is None:
+        code = _block_code(match.missing, mutation_mode=mutation_mode)
+        return requirement, _blocked(
+            code,
+            _block_message(code, dispatch.site),
+            requirement,
+            missing=match.missing,
+        )
+
+    selected = match.selected
+    profile_binding_id = None
+    session_snapshot_id = None
+    lock_id = None
+    if match.requiresSiteBinding:
+        profile_binding_id = _resource_id("profile-binding", dispatch.site, selected.endpoint)
+        if mutation_mode == "write":
+            lock_id = _resource_id("profile-lock", dispatch.site, selected.endpoint)
+        else:
+            session_snapshot_id = _resource_id(
+                "session-snapshot", dispatch.site, selected.endpoint
+            )
+    return requirement, WorkflowRuntimeResourceResolution(
+        status="resolved",
+        adapterNodeId=match.adapterNodeId or adapter_node_id,
+        command=match.command or dispatch.command,
+        workerSlotId=selected.endpoint,
+        profileBindingId=profile_binding_id,
+        sessionSnapshotId=session_snapshot_id,
+        lockId=lock_id,
+        concurrencyLimit=1,
+    )
+
+
+async def resolve_runtime_resources_from_db(
+    session: AsyncSession,
+    requirement: WorkflowRuntimeResourceRequirement,
+    *,
+    worker_slot_id: str | None = None,
+) -> WorkflowRuntimeResourceResolution:
+    """Resolve registered profile and snapshot resources against the control plane."""
+    if requirement.mutationMode not in {"read", "write"}:
+        return _blocked(
+            MUTATION_MODE_UNSUPPORTED,
+            f"Unsupported browser mutation mode: {requirement.mutationMode!r}.",
+            requirement,
+        )
+
+    profile_row = (
+        await session.execute(
+            select(ProfileBindingRow).where(
+                ProfileBindingRow.site == requirement.site,
+                ProfileBindingRow.active.is_(True),
+            )
+        )
+    ).scalar_one_or_none()
+    browser_row = None
+    if profile_row is None:
+        browser_row = (
+            await session.execute(
+                select(BrowserBinding).where(BrowserBinding.site == requirement.site)
+            )
+        ).scalar_one_or_none()
+    if profile_row is None and browser_row is None:
+        return _blocked(
+            MISSING_PROFILE_BINDING,
+            f'No browser profile binding is available for "{requirement.site}".',
+            requirement,
+        )
+
+    pool = _read_pool()
+    endpoint = worker_slot_id or (
+        profile_row.browser_endpoint if profile_row is not None else browser_row.browser_endpoint
+    )
+    if pool is None or endpoint not in pool.endpoints:
+        return _blocked(
+            MISSING_WORKER_CAPACITY,
+            "No registered browser-worker slot satisfies the requirement.",
+            requirement,
+            endpoint=endpoint,
+        )
+
+    profile_binding_id = profile_row.id if profile_row is not None else browser_row.id
+    if requirement.mutationMode == "write":
+        lock = await profile_locks.acquire(profile_binding_id, endpoint)
+        if lock is None:
+            return _blocked(
+                PROFILE_LOCK_CONTENDED,
+                f'The browser profile lock for "{requirement.site}" is already held.',
+                requirement,
+                profileBindingId=profile_binding_id,
+            )
+        return WorkflowRuntimeResourceResolution(
+            status="resolved",
+            workerSlotId=endpoint,
+            profileBindingId=profile_binding_id,
+            lockId=lock.lock_id,
+        )
+
+    snapshot = (
+        await session.execute(
+            select(SessionSnapshotRow)
+            .where(SessionSnapshotRow.profile_binding_id == profile_binding_id)
+            .order_by(SessionSnapshotRow.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if snapshot is None:
+        return _blocked(
+            MISSING_SESSION_SNAPSHOT,
+            f'No shareable browser session snapshot is available for "{requirement.site}".',
+            requirement,
+            profileBindingId=profile_binding_id,
+        )
+    return WorkflowRuntimeResourceResolution(
+        status="resolved",
+        workerSlotId=endpoint,
+        profileBindingId=profile_binding_id,
+        sessionSnapshotId=snapshot.snapshot_id,
+    )
+
+
+@asynccontextmanager
+async def profile_mutation_lock(
+    profile_binding_id: str,
+    worker_slot_id: str,
+) -> AsyncIterator[ProfileLock]:
+    """Hold an exclusive profile mutation lock for the context lifetime."""
+    lock = await profile_locks.acquire(profile_binding_id, worker_slot_id)
+    if lock is None:
+        raise RuntimeError("profile lock is already held")
+    try:
+        yield lock
+    finally:
+        await profile_locks.release(lock.lock_id)
+
+
+def _blocked(
+    code: str,
+    message: str,
+    requirement: WorkflowRuntimeResourceRequirement,
+    *,
+    missing: list[str] | None = None,
+    **details: Any,
+) -> WorkflowRuntimeResourceResolution:
+    return WorkflowRuntimeResourceResolution(
+        status="blocked",
+        adapterNodeId=requirement.adapterNodeId,
+        blockReason=WorkflowRunBlockReason(
+            code=code,
+            message=message,
+            source="workflow_runtime_resources",
+            details={
+                "nodeId": requirement.nodeId,
+                "sourceGroup": requirement.sourceGroup,
+                "site": requirement.site,
+                "mutationMode": requirement.mutationMode,
+                "requestedCapability": requirement.requestedCapability,
+                "adapterNodeId": requirement.adapterNodeId,
+                "missing": missing or [],
+                **details,
+            },
+        ),
+    )
+
+
+def _block_code(missing: list[str], *, mutation_mode: str) -> str:
+    if "opencli_adapter_node" in missing:
+        return MISSING_ADAPTER_RESOURCE
+    if any(value.startswith("site_binding:") for value in missing):
+        return MISSING_PROFILE_BINDING
+    if "profile_lock" in missing and mutation_mode == "write":
+        return PROFILE_LOCK_CONTENDED
+    if "session_snapshot" in missing:
+        return MISSING_SESSION_SNAPSHOT
+    return MISSING_WORKER_CAPACITY
+
+
+def _block_message(code: str, site: str) -> str:
+    if code == MISSING_ADAPTER_RESOURCE:
+        return "OpenCLI adapter capability is unavailable in the registered catalog."
+    if code == MISSING_PROFILE_BINDING:
+        return f'No browser profile/site binding is available for "{site}".'
+    if code == MISSING_SESSION_SNAPSHOT:
+        return f'No shareable browser session snapshot is available for "{site}".'
+    if code == PROFILE_LOCK_CONTENDED:
+        return f'The browser profile lock for "{site}" is already held.'
+    return "No connected worker slot currently has capacity for this OpenCLI task."
+
+
+def _resource_id(kind: str, site: str, endpoint: str) -> str:
+    return str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"opencli-admin/runtime-resource/{kind}/{site}/{endpoint}",
+        )
+    )
+
+
+def _read_pool():
+    try:
+        return get_pool()
+    except RuntimeError:
+        return None
+
+
+def _read_string(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+__all__ = [
+    "ProfileBinding",
+    "ProfileLock",
+    "ProfileLockManager",
+    "SessionSnapshot",
+    "SessionSnapshotStore",
+    "profile_locks",
+    "profile_mutation_lock",
+    "resolve_runtime_resources",
+    "resolve_runtime_resources_from_db",
+    "session_snapshots",
+]

--- a/frontend/app/api/workflow/evidence-proxy.ts
+++ b/frontend/app/api/workflow/evidence-proxy.ts
@@ -1,0 +1,37 @@
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://127.0.0.1:8031"
+
+export async function proxyWorkflowEvidenceRequest(
+  req: Request,
+  runId: string,
+  suffix = "",
+): Promise<Response> {
+  try {
+    const url = new URL(req.url)
+    const search = url.searchParams.toString()
+    const response = await fetch(
+      `${BACKEND_URL}/api/v1/workflows/runs/${encodeURIComponent(runId)}${suffix}${search ? `?${search}` : ""}`,
+      {
+        headers: {
+          ...(req.headers.get("authorization")
+            ? { Authorization: req.headers.get("authorization") as string }
+            : {}),
+        },
+        cache: "no-store",
+      },
+    )
+    const payload = await response.json().catch(() => null)
+    return Response.json(payload, {
+      status: response.status,
+      headers: { "Cache-Control": "no-store" },
+    })
+  } catch (error) {
+    return Response.json(
+      {
+        success: false,
+        error: "WORKFLOW_EVIDENCE_PROJECTION_FAILED",
+        message: error instanceof Error ? error.message : "Unknown workflow evidence projection error",
+      },
+      { status: 502 },
+    )
+  }
+}

--- a/frontend/app/api/workflow/run/route.ts
+++ b/frontend/app/api/workflow/run/route.ts
@@ -1,4 +1,3 @@
-import workflowFixture from "../../../../lib/workflow/fixtures/workflow-intelligence.json"
 import { parseWorkflowProject } from "../../../../lib/workflow/schema"
 
 export const dynamic = "force-dynamic"
@@ -7,8 +6,8 @@ const BACKEND_URL = process.env.BACKEND_URL ?? "http://127.0.0.1:8031"
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json().catch(() => ({ project: workflowFixture }))
-    const project = parseWorkflowProject(body?.project ?? body ?? workflowFixture)
+    const body = await req.json()
+    const project = parseWorkflowProject(body?.project ?? body)
     const response = await fetch(`${BACKEND_URL}/api/v1/workflows/runs`, {
       method: "POST",
       headers: {

--- a/frontend/app/api/workflow/runs/[runId]/evidence-batches/[batchId]/route.ts
+++ b/frontend/app/api/workflow/runs/[runId]/evidence-batches/[batchId]/route.ts
@@ -1,0 +1,8 @@
+import { proxyWorkflowEvidenceRequest } from "../../../../evidence-proxy"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(req: Request, context: { params: Promise<{ runId: string; batchId: string }> }) {
+  const { runId, batchId } = await context.params
+  return proxyWorkflowEvidenceRequest(req, runId, `/evidence-batches/${encodeURIComponent(batchId)}`)
+}

--- a/frontend/app/api/workflow/runs/[runId]/evidence-batches/projection/route.ts
+++ b/frontend/app/api/workflow/runs/[runId]/evidence-batches/projection/route.ts
@@ -1,0 +1,8 @@
+import { proxyWorkflowEvidenceRequest } from "../../../../evidence-proxy"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(req: Request, context: { params: Promise<{ runId: string }> }) {
+  const { runId } = await context.params
+  return proxyWorkflowEvidenceRequest(req, runId, "/projection")
+}

--- a/frontend/app/api/workflow/runs/[runId]/evidence-batches/route.ts
+++ b/frontend/app/api/workflow/runs/[runId]/evidence-batches/route.ts
@@ -1,0 +1,8 @@
+import { proxyWorkflowEvidenceRequest } from "../../../evidence-proxy"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(req: Request, context: { params: Promise<{ runId: string }> }) {
+  const { runId } = await context.params
+  return proxyWorkflowEvidenceRequest(req, runId, "/evidence-batches")
+}

--- a/frontend/components/flow/workflow-canvas-surface.tsx
+++ b/frontend/components/flow/workflow-canvas-surface.tsx
@@ -20,6 +20,7 @@ import {
 
 import type { CanvasSettings } from "@/lib/flow/settings-store"
 import type { FlowState } from "@/lib/flow/store"
+import type { EvidenceWorkbenchState } from "@/lib/workflow/evidence-workbench"
 import type { ToolMode, WorkflowEdge, WorkflowNode } from "@/lib/flow/types"
 import type { WorkflowCapabilitiesResponse } from "@/lib/workflow/capabilities"
 import type { WorkflowNodeCatalogItem } from "@/lib/workflow/node-catalog"
@@ -92,6 +93,7 @@ type WorkflowCanvasSurfaceProps = {
   networkLocked: boolean
   networkStack: FlowState["networkStack"]
   nodeManagementOpen: boolean
+  resultWorkbenchState?: EvidenceWorkbenchState
   nodeMenu: NodeMenuState | null
   nodes: WorkflowNode[]
   onBeforeDelete: OnBeforeDelete<WorkflowNode, WorkflowEdge>
@@ -263,6 +265,44 @@ function CanvasLayers({
   )
 }
 
+function ResultWorkbenchOverlay({ state }: { state: EvidenceWorkbenchState }) {
+  const batches = state.batches
+  const records = batches.reduce((sum, batch) => sum + batch.recordCount, 0)
+  return (
+    <aside className="absolute bottom-3 right-3 top-3 z-40 flex w-80 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-md border bg-card/95 shadow-overlay backdrop-blur-sm" aria-label="Evidence result workbench">
+      <div className="border-b border-border px-4 py-3">
+        <p className="font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">Result Workbench</p>
+        <h2 className="mt-1 text-sm font-medium">Evidence batches</h2>
+        <div className="mt-3 grid grid-cols-3 gap-1.5 font-mono text-2xs">
+          <span className="rounded-xs border border-border bg-background p-1.5">{batches.length} batches</span>
+          <span className="rounded-xs border border-border bg-background p-1.5">{records} records</span>
+          <span className="rounded-xs border border-border bg-background p-1.5">{state.projection?.missingSources.length ?? 0} missing</span>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-3">
+        {state.error ? <p className="rounded-xs border border-amber-500/30 bg-amber-500/10 p-2 text-2xs text-amber-400">{state.error}</p> : null}
+        {state.projection?.missingSources.map((source) => (
+          <div key={`${source.nodeId}-${source.code}`} className="rounded-xs border border-amber-500/30 bg-amber-500/10 p-2 text-2xs">
+            <p className="font-mono text-amber-400">{source.nodeId ?? source.sourceGroup ?? "source"}</p>
+            <p className="mt-1 text-muted-foreground">{source.reason ?? source.code ?? "Source is incomplete"}</p>
+          </div>
+        ))}
+        {batches.map((batch) => (
+          <div key={batch.batchId} className="rounded-xs border border-border bg-background p-2">
+            <div className="flex items-center justify-between gap-2 font-mono text-2xs">
+              <span className="truncate">{batch.batchId}</span>
+              <span className="uppercase text-muted-foreground">{batch.status}</span>
+            </div>
+            <p className="mt-1 truncate font-mono text-3xs text-muted-foreground">{batch.nodeId} · {batch.sourceGroup ?? "ungrouped"}</p>
+            <p className="mt-1 font-mono text-3xs text-muted-foreground">{batch.itemCount} items · {batch.recordCount} records</p>
+          </div>
+        ))}
+        {state.status === "ready" && batches.length === 0 ? <p className="rounded-xs border border-dashed border-border p-3 text-center text-2xs text-muted-foreground">No evidence batch output.</p> : null}
+      </div>
+    </aside>
+  )
+}
+
 export function WorkflowCanvasSurface(props: WorkflowCanvasSurfaceProps) {
   const interactionLocked = props.isDraw || props.isScissors
   const flowInteraction = flowInteractionProps(props.settings, interactionLocked)
@@ -356,6 +396,9 @@ export function WorkflowCanvasSurface(props: WorkflowCanvasSurfaceProps) {
       />
 
       <WorkflowToast message={props.toast} />
+      {props.resultWorkbenchState && props.resultWorkbenchState.status !== "idle" ? (
+        <ResultWorkbenchOverlay state={props.resultWorkbenchState} />
+      ) : null}
     </div>
   )
 }

--- a/frontend/components/flow/workflow-editor-effects.ts
+++ b/frontend/components/flow/workflow-editor-effects.ts
@@ -1,10 +1,19 @@
 "use client"
 
-import { useCallback, useEffect, type Dispatch, type SetStateAction } from "react"
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react"
 
 import { useFlowStore } from "@/lib/flow/store"
-import { loadShareStateFromUrl } from "@/lib/flow/share-state"
+import { getApiAuthToken } from "@/lib/api/auth-token"
+import {
+  fetchWorkflowEvidenceBatches,
+  fetchWorkflowEvidenceProjection,
+  fetchWorkflowRunProjection,
+  replayWorkflowRunEventStream,
+} from "@/lib/workflow/backend-runs"
+import type { WorkflowRunProjection } from "@/lib/workflow/backend-runs"
 import type { WorkflowCapabilitiesResponse } from "@/lib/workflow/capabilities"
+import { loadShareStateFromUrl } from "@/lib/flow/share-state"
+import { emptyEvidenceWorkbenchState, type EvidenceWorkbenchState } from "@/lib/workflow/evidence-workbench"
 import type { WorkflowNode } from "@/lib/flow/types"
 import type { NodeMenuState } from "./workflow-node-menu-actions"
 
@@ -89,6 +98,82 @@ export function useCompactViewportEffect(applyCompactViewport: () => number | un
       if (timer) window.clearTimeout(timer)
     }
   }, [applyCompactViewport])
+}
+
+export function useWorkflowResultSubscription(options: {
+  projection: WorkflowRunProjection | null
+  setWorkbenchState: Dispatch<SetStateAction<EvidenceWorkbenchState>>
+}) {
+  const { projection: requestedProjection, setWorkbenchState } = options
+  const [, setActiveProjection] = useState<WorkflowRunProjection | null>(requestedProjection)
+  const applyWorkflowNodeRunEvent = useFlowStore((state) => state.applyWorkflowNodeRunEvent)
+  const applyWorkflowRunProjection = useFlowStore((state) => state.applyWorkflowRunProjection)
+  const applyWorkflowEvidenceBatchProjection = useFlowStore(
+    (state) => state.applyWorkflowEvidenceBatchProjection,
+  )
+
+  useEffect(() => {
+    if (!requestedProjection?.runId) {
+      setActiveProjection(null)
+      setWorkbenchState(emptyEvidenceWorkbenchState())
+      return
+    }
+
+    const runId = requestedProjection.runId
+    const controller = new AbortController()
+    const token = getApiAuthToken()
+    const authorization = token ? `Bearer ${token}` : null
+    setWorkbenchState((current) => ({ ...current, status: "loading", error: null }))
+
+    void (async () => {
+      try {
+        const latestProjection = await fetchWorkflowRunProjection(runId, { authorization })
+        applyWorkflowRunProjection(latestProjection)
+        const replay = await replayWorkflowRunEventStream(runId, {
+          authorization,
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        for (const event of replay.events) applyWorkflowNodeRunEvent(event)
+        if (replay.projection) {
+          setActiveProjection(replay.projection)
+          applyWorkflowRunProjection(replay.projection)
+        }
+
+        const [batchList, evidenceProjection] = await Promise.all([
+          fetchWorkflowEvidenceBatches(runId, { authorization }),
+          fetchWorkflowEvidenceProjection(runId, {
+            authorization,
+            include: ["clusters", "missingSources", "summaries", "conflicts"],
+          }),
+        ])
+        if (controller.signal.aborted) return
+        applyWorkflowEvidenceBatchProjection(evidenceProjection, batchList.batches)
+        setWorkbenchState({
+          status: "ready",
+          projection: evidenceProjection,
+          batches: batchList.batches,
+          selectedBatchId: null,
+          error: null,
+        })
+      } catch (error) {
+        if (controller.signal.aborted) return
+        setWorkbenchState((current) => ({
+          ...current,
+          status: "error",
+          error: error instanceof Error ? error.message : "Workflow result subscription failed",
+        }))
+      }
+    })()
+
+    return () => controller.abort()
+  }, [
+    applyWorkflowEvidenceBatchProjection,
+    applyWorkflowNodeRunEvent,
+    applyWorkflowRunProjection,
+    requestedProjection?.runId,
+    setWorkbenchState,
+  ])
 }
 
 export function useExitCurrentNetwork(options: {

--- a/frontend/components/flow/workflow-editor-selectors.ts
+++ b/frontend/components/flow/workflow-editor-selectors.ts
@@ -45,5 +45,6 @@ export function selectEditorCanvasState(state: FlowState) {
     unlockNodeInternals: state.unlockNodeInternals,
     updateWorkflowProfile: state.updateWorkflowProfile,
     workflowProject: state.workflowProject,
+    workflowRunProjection: state.workflowRunProjection,
   }
 }

--- a/frontend/components/flow/workflow-editor.tsx
+++ b/frontend/components/flow/workflow-editor.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react"
+import { emptyEvidenceWorkbenchState, type EvidenceWorkbenchState } from "@/lib/workflow/evidence-workbench"
 import { ReactFlowProvider, useReactFlow, type NodeMouseHandler } from "@xyflow/react"
 import "@xyflow/react/dist/style.css"
 
@@ -35,6 +36,7 @@ import {
   useDismissNodeMenu,
   useExitCurrentNetwork,
   useSharedWorkflowImport,
+  useWorkflowResultSubscription,
 } from "./workflow-editor-effects"
 
 function buildPrimitiveMenuGroups() {
@@ -86,6 +88,7 @@ function EditorCanvas() {
     unlockNodeInternals,
     updateWorkflowProfile,
     workflowProject,
+    workflowRunProjection,
   } = useFlowStore(selectEditorCanvasState)
 
   const settings = useSettingsStore()
@@ -109,6 +112,7 @@ function EditorCanvas() {
   const [zoom, setZoom] = useState(1)
   const [compactViewport, setCompactViewport] = useState(false)
   const [nodeMenu, setNodeMenu] = useState<NodeMenuState | null>(null)
+  const [resultWorkbenchState, setResultWorkbenchState] = useState<EvidenceWorkbenchState>(emptyEvidenceWorkbenchState)
   const { capabilities } = useWorkflowCapabilities(true)
   const dopNodeMenuItems = useMemo(
     () => getWorkflowNodeCatalog(workflowProject.profile, capabilities),
@@ -126,6 +130,10 @@ function EditorCanvas() {
   useCompactViewportMedia(setCompactViewport)
   const applyCompactViewport = useCanvasViewportCompaction({ compactViewport, nodes, setViewport })
   useCompactViewportEffect(applyCompactViewport)
+  useWorkflowResultSubscription({
+    projection: workflowRunProjection,
+    setWorkbenchState: setResultWorkbenchState,
+  })
 
   useWorkflowKeyboardShortcuts({
     autoLayout,
@@ -285,6 +293,7 @@ function EditorCanvas() {
           nodeManagementOpen={nodeManagementOpen}
           nodeMenu={nodeMenu}
           nodes={nodes}
+          resultWorkbenchState={resultWorkbenchState}
           onBeforeDelete={onBeforeDelete}
           onCanvasMouseDownCapture={onCanvasMouseDownCapture}
           onCanvasMouseMoveCapture={onCanvasMouseMoveCapture}

--- a/frontend/lib/flow/store.ts
+++ b/frontend/lib/flow/store.ts
@@ -52,7 +52,10 @@ import type {
   WorkflowRunNodeState,
   WorkflowRunProjection,
   WorkflowRunStatus,
+  WorkflowEvidenceBatchSummary,
+  WorkflowEvidenceProjection,
 } from "../workflow/backend-runs"
+import { applyEvidenceBatchRuntimePatches } from "../workflow/runtime-bridge"
 
 export type { GeneratedWorkflowSpec } from "./types"
 
@@ -62,6 +65,7 @@ const initialWorkflowFlow = workflowProjectToReactFlow(initialWorkflowProject)
 
 export type FlowState = {
   workflowProject: WorkflowProject
+  workflowRunProjection: WorkflowRunProjection | null
   nodes: WorkflowNode[]
   edges: WorkflowEdge[]
   networkStack: { nodeId: string; label: string; snapshot: FlowSnapshot }[]
@@ -157,6 +161,10 @@ export type FlowState = {
   applyWorkflowCapabilities: (capabilities: WorkflowCapabilitiesResponse) => void
   applyWorkflowNodeRunEvent: (event: WorkflowNodeRunEvent) => void
   applyWorkflowRunProjection: (projection: WorkflowRunProjection) => void
+  applyWorkflowEvidenceBatchProjection: (
+    projection: WorkflowEvidenceProjection,
+    batches: WorkflowEvidenceBatchSummary[],
+  ) => void
   updateWorkflowProfile: (profile: WorkflowProfile) => void
   queueAgentProposal: (proposal: AgentProposal) => void
   clearPendingAgentProposal: () => void
@@ -578,6 +586,7 @@ function writeBoundValueToNode(
 
 export const useFlowStore = create<FlowState>((set, get) => ({
   workflowProject: initialWorkflowProject,
+  workflowRunProjection: null,
   nodes: initialWorkflowFlow.nodes,
   edges: initialWorkflowFlow.edges,
   networkStack: [],
@@ -1113,6 +1122,7 @@ export const useFlowStore = create<FlowState>((set, get) => ({
       })
       return {
         workflowProject: nextProject,
+        workflowRunProjection: projection,
         nodes: state.nodes.map((node) => {
           const runtimeRunState = stateByCanvasNodeId.get(node.id)
           if (!runtimeRunState) return node
@@ -1135,6 +1145,13 @@ export const useFlowStore = create<FlowState>((set, get) => ({
           }
         }),
       }
+    })
+  },
+
+  applyWorkflowEvidenceBatchProjection: (projection, batches) => {
+    set((state) => {
+      const patched = applyEvidenceBatchRuntimePatches(state.nodes, state.edges, projection, batches)
+      return { nodes: patched.nodes, edges: patched.edges }
     })
   },
 

--- a/frontend/lib/flow/types.ts
+++ b/frontend/lib/flow/types.ts
@@ -126,6 +126,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   runtimeCapability?: WorkflowRuntimeCapability
   runtimeRunState?: WorkflowRunNodeState
   runtimeLatestEvent?: WorkflowNodeRunEvent
+  runtimeEvidenceBatches?: import("@/lib/workflow/backend-runs").WorkflowEvidenceBatchSummary[]
   /** node-internal mini network preview */
   miniNetwork?: MiniNetworkPreview
   /** topic collapse as package internals */
@@ -152,6 +153,13 @@ export interface WorkflowEdgeData extends Record<string, unknown> {
   waypoints?: XYPosition[]
   /** enable smart orthogonal routing that avoids nodes */
   routed?: boolean
+  runtimeEvidenceBatch?: {
+    runId: string
+    status: "queued" | "running" | "partial" | "blocked" | "completed" | "failed"
+    batchIds: string[]
+    itemCount: number
+    recordCount: number
+  }
 }
 
 export type WorkflowEdge = Edge<WorkflowEdgeData>

--- a/frontend/lib/workflow/backend-runs.ts
+++ b/frontend/lib/workflow/backend-runs.ts
@@ -37,6 +37,91 @@ export type WorkflowRunBatchReference = {
   manifestUri?: string | null
 }
 
+export type WorkflowEvidenceBatchStatus =
+  | "ready"
+  | "partial"
+  | "blocked"
+  | "failed"
+  | "completed"
+  | "ingested"
+  | "missing"
+
+export type WorkflowEvidenceBatchSummary = WorkflowRunBatchReference & {
+  runId: string
+  nodeId: string
+  packageNodeId?: string | null
+  internalNodeId?: string | null
+  sourceGroup?: string | null
+  adapterTaskId?: string | null
+  traceId?: string | null
+  status: WorkflowEvidenceBatchStatus
+  createdAt?: string | null
+}
+
+export type WorkflowEvidenceBatchListResponse = {
+  runId: string
+  batches: WorkflowEvidenceBatchSummary[]
+  nextCursor?: string | null
+}
+
+export type WorkflowEvidenceBatchSourceCoverage = {
+  sourceGroup?: string | null
+  site?: string | null
+  command?: string | null
+  itemCount: number
+  recordCount: number
+  status: WorkflowEvidenceBatchStatus
+}
+
+export type WorkflowEvidenceBatchDetailResponse = {
+  runId: string
+  batch: WorkflowEvidenceBatchSummary
+  manifestUri?: string | null
+  odpRef?: string | null
+  recordCount: number
+  itemCount: number
+  sourceCoverage: WorkflowEvidenceBatchSourceCoverage[]
+}
+
+export type WorkflowEvidenceNodeProjection = {
+  nodeId: string
+  packageNodeId?: string | null
+  internalNodeId?: string | null
+  sourceGroup?: string | null
+  status?: string | null
+  itemCount: number
+  batchRefs: string[]
+  blockReasons: string[]
+}
+
+export type WorkflowEvidenceMissingSource = {
+  nodeId?: string | null
+  packageNodeId?: string | null
+  internalNodeId?: string | null
+  sourceGroup?: string | null
+  site?: string | null
+  command?: string | null
+  reason?: string | null
+  code?: string | null
+  details: Record<string, unknown>
+}
+
+export type WorkflowEvidenceProjection = {
+  runId: string
+  status: WorkflowRunStatus
+  valid: boolean
+  nodes: WorkflowEvidenceNodeProjection[]
+  clusters: Array<Record<string, unknown>>
+  missingSources: WorkflowEvidenceMissingSource[]
+  summaries: Array<Record<string, unknown>>
+  conflicts: Array<Record<string, unknown>>
+  artifacts: Array<Record<string, unknown>>
+  batches: WorkflowEvidenceBatchSummary[]
+}
+
+const workflowRunEndpoint = (runId: string) => `/api/workflow/runs/${encodeURIComponent(runId)}`
+const workflowEvidenceBatchesEndpoint = (runId: string) => `${workflowRunEndpoint(runId)}/evidence-batches`
+
 export type WorkflowNodeRunEvent = {
   id: string
   sequence: number
@@ -238,13 +323,14 @@ export async function continueWorkflowRunWithSourceOutputs(
 
 export async function replayWorkflowRunEventStream(
   runId: string,
-  options: { authorization?: string | null } = {},
+  options: { authorization?: string | null; signal?: AbortSignal } = {},
 ): Promise<WorkflowRunStreamReplay> {
   const response = await fetch(`/api/workflow/runs/${encodeURIComponent(runId)}/events/stream`, {
     headers: {
       ...(options.authorization ? { Authorization: options.authorization } : {}),
     },
     cache: "no-store",
+    signal: options.signal,
   })
   if (!response.ok) {
     const payload = (await response.json().catch(() => null)) as { message?: string; error?: string } | null
@@ -252,6 +338,73 @@ export async function replayWorkflowRunEventStream(
   }
   const text = await response.text()
   return parseWorkflowRunEventStream(text)
+}
+
+export async function fetchWorkflowEvidenceBatches(
+  runId: string,
+  options: {
+    authorization?: string | null
+    nodeId?: string
+    sourceGroup?: string
+    cursor?: string
+    limit?: number
+    signal?: AbortSignal
+  } = {},
+): Promise<WorkflowEvidenceBatchListResponse> {
+  const search = new URLSearchParams()
+  if (options.nodeId) search.set("nodeId", options.nodeId)
+  if (options.sourceGroup) search.set("sourceGroup", options.sourceGroup)
+  if (options.cursor) search.set("cursor", options.cursor)
+  if (typeof options.limit === "number") search.set("limit", String(options.limit))
+  const suffix = search.size > 0 ? `?${search.toString()}` : ""
+  const response = await fetch(`/api/workflow/runs/${encodeURIComponent(runId)}/evidence-batches${suffix}`, {
+    headers: {
+      ...(options.authorization ? { Authorization: options.authorization } : {}),
+    },
+    cache: "no-store",
+    signal: options.signal,
+  })
+  return readApiResponse(response, "Workflow evidence batches failed")
+}
+
+export async function fetchWorkflowEvidenceBatchDetail(
+  runId: string,
+  batchId: string,
+  options: { authorization?: string | null } = {},
+): Promise<WorkflowEvidenceBatchDetailResponse> {
+  const response = await fetch(
+    `${workflowRunEndpoint(runId)}/evidence-batches/${encodeURIComponent(batchId)}`,
+    {
+      headers: {
+        ...(options.authorization ? { Authorization: options.authorization } : {}),
+      },
+      cache: "no-store",
+    },
+  )
+  return readApiResponse(response, "Workflow evidence batch detail failed")
+}
+
+export async function fetchWorkflowEvidenceProjection(
+  runId: string,
+  options: {
+    authorization?: string | null
+    nodeId?: string
+    sourceGroup?: string
+    include?: string[]
+  } = {},
+): Promise<WorkflowEvidenceProjection> {
+  const search = new URLSearchParams()
+  if (options.nodeId) search.set("nodeId", options.nodeId)
+  if (options.sourceGroup) search.set("sourceGroup", options.sourceGroup)
+  if (options.include?.length) search.set("include", options.include.join(","))
+  const suffix = search.size > 0 ? `?${search.toString()}` : ""
+  const response = await fetch(`/api/workflow/runs/${encodeURIComponent(runId)}/evidence-batches/projection${suffix}`, {
+    headers: {
+      ...(options.authorization ? { Authorization: options.authorization } : {}),
+    },
+    cache: "no-store",
+  })
+  return readApiResponse(response, "Workflow evidence projection failed")
 }
 
 export function parseWorkflowRunEventStream(text: string): WorkflowRunStreamReplay {

--- a/frontend/lib/workflow/evidence-workbench.ts
+++ b/frontend/lib/workflow/evidence-workbench.ts
@@ -1,0 +1,139 @@
+"use client"
+
+import { Loader2 } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import type {
+  WorkflowEdge,
+  WorkflowNode,
+  WorkflowNodeData,
+} from "@/lib/flow/types"
+import type {
+  WorkflowEvidenceBatchStatus,
+  WorkflowEvidenceBatchSummary,
+  WorkflowEvidenceProjection,
+} from "./backend-runs"
+
+export type EvidenceWorkbenchState = {
+  status: "idle" | "loading" | "ready" | "error"
+  projection: WorkflowEvidenceProjection | null
+  batches: WorkflowEvidenceBatchSummary[]
+  selectedBatchId: string | null
+  error: string | null
+}
+
+export function emptyEvidenceWorkbenchState(): EvidenceWorkbenchState {
+  return {
+    status: "idle",
+    projection: null,
+    batches: [],
+    selectedBatchId: null,
+    error: null,
+  }
+}
+
+export function evidenceWorkbenchMetrics(
+  state: Pick<EvidenceWorkbenchState, "projection" | "batches">,
+) {
+  const projection = state.projection
+  return {
+    batchCount: state.batches.length,
+    itemCount: state.batches.reduce((sum, batch) => sum + batch.itemCount, 0),
+    recordCount: state.batches.reduce((sum, batch) => sum + batch.recordCount, 0),
+    partialCount: state.batches.filter((batch) => batch.status === "partial").length,
+    blockedCount: projection?.nodes.filter((node) => node.status === "blocked" || node.status === "failed").length ?? 0,
+    missingSourceCount: projection?.missingSources.length ?? 0,
+  }
+}
+
+export function evidenceBatchStatus(batches: WorkflowEvidenceBatchSummary[]): WorkflowEvidenceBatchStatus {
+  if (batches.some((batch) => batch.status === "blocked")) return "blocked"
+  if (batches.some((batch) => batch.status === "failed")) return "failed"
+  if (batches.some((batch) => batch.status === "partial")) return "partial"
+  if (batches.some((batch) => batch.status === "ready")) return "ready"
+  if (batches.some((batch) => batch.status === "missing")) return "missing"
+  return "completed"
+}
+
+export function applyEvidenceWorkbenchNodeState(
+  nodes: WorkflowNode[],
+  edges: WorkflowEdge[],
+  projection: WorkflowEvidenceProjection,
+  batches: WorkflowEvidenceBatchSummary[],
+): { nodes: WorkflowNode[]; edges: WorkflowEdge[] } {
+  const batchesByNodeId = new Map<string, WorkflowEvidenceBatchSummary[]>()
+  for (const batch of batches) {
+    for (const nodeId of visibleNodeIds(batch.nodeId, batch.packageNodeId)) {
+      batchesByNodeId.set(nodeId, [...(batchesByNodeId.get(nodeId) ?? []), batch])
+    }
+  }
+
+  const nextNodes = nodes.map((node) => {
+    const nodeBatches = batchesByNodeId.get(node.id)
+    if (!nodeBatches) return node
+    const status = evidenceBatchStatus(nodeBatches)
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        status: canvasStatus(status),
+        runtimeEvidenceBatches: nodeBatches,
+        runtimePreview: {
+          ...node.data.runtimePreview,
+          status: `evidence-${status}`,
+          runId: projection.runId,
+          diagnostic: latestMissingSourceMessage(projection, node.id) ?? node.data.runtimePreview?.diagnostic,
+        },
+      },
+    }
+  })
+
+  const nextEdges = edges.map((edge) => {
+    const nodeBatches = batchesByNodeId.get(edge.source)
+    if (!nodeBatches) return edge
+    const status = evidenceBatchStatus(nodeBatches)
+    return {
+      ...edge,
+      animated: status === "partial" || status === "ready",
+      data: {
+        ...edge.data,
+        runtimeEvidenceBatch: {
+          runId: projection.runId,
+          status: toRunStatus(status),
+          batchIds: nodeBatches.map((batch) => batch.batchId),
+          itemCount: nodeBatches.reduce((sum, batch) => sum + batch.itemCount, 0),
+          recordCount: nodeBatches.reduce((sum, batch) => sum + batch.recordCount, 0),
+        },
+      },
+    }
+  })
+
+  return { nodes: nextNodes, edges: nextEdges }
+}
+
+function visibleNodeIds(nodeId: string, packageNodeId?: string | null): string[] {
+  const ids = [nodeId]
+  if (packageNodeId) ids.push(packageNodeId)
+  const separatorIndex = nodeId.indexOf("::")
+  if (separatorIndex > 0) ids.push(nodeId.replace("::", "__"))
+  return Array.from(new Set(ids))
+}
+
+function latestMissingSourceMessage(projection: WorkflowEvidenceProjection, nodeId: string): string | undefined {
+  return projection.missingSources.find((source) =>
+    [source.nodeId, source.packageNodeId, source.internalNodeId].includes(nodeId),
+  )?.reason ?? undefined
+}
+
+function canvasStatus(status: WorkflowEvidenceBatchStatus): WorkflowNodeData["status"] {
+  if (status === "completed" || status === "ingested") return "success"
+  if (status === "blocked" || status === "failed" || status === "missing") return "error"
+  return "running"
+}
+
+function toRunStatus(status: WorkflowEvidenceBatchStatus): "queued" | "running" | "partial" | "blocked" | "completed" | "failed" {
+  if (status === "ready") return "running"
+  if (status === "ingested") return "completed"
+  if (status === "missing") return "blocked"
+  return status
+}

--- a/frontend/lib/workflow/node-catalog.ts
+++ b/frontend/lib/workflow/node-catalog.ts
@@ -713,14 +713,106 @@ export const WORKFLOW_NODE_CATALOG: WorkflowNodeCatalogItem[] = [
   },
 ]
 
+type CanvasSourceManifest = {
+  catalogId: string
+  idPrefix: string
+  label: string
+  description: string
+  category: "source"
+  icon: string
+  color: string
+  keywords: string[]
+  adapter: AdapterBinding
+  params: Record<string, unknown>
+}
+
 export function getWorkflowNodeCatalog(
   profile: WorkflowProfile,
   capabilities?: WorkflowCapabilitiesResponse | null,
 ): WorkflowNodeCatalogItem[] {
-  return WORKFLOW_NODE_CATALOG.filter((item) => item.profile === profile).map((item) => ({
+  const staticItems = WORKFLOW_NODE_CATALOG.filter((item) => item.profile === profile).map((item) => ({
     ...item,
     runtimeCapability: catalogRuntimeCapability(capabilities, item.id),
   }))
+  if (profile !== "intelligence") return staticItems
+
+  const staticIds = new Set(staticItems.map((item) => item.id))
+  const projectedSources = (capabilities?.catalog ?? [])
+    .map(channelSourceCatalogItem)
+    .filter((item): item is WorkflowNodeCatalogItem => item !== null && !staticIds.has(item.id))
+  return [...staticItems, ...projectedSources]
+}
+
+function channelSourceCatalogItem(
+  capability: WorkflowRuntimeCapability,
+): WorkflowNodeCatalogItem | null {
+  if (capability.surface !== "catalog" || capability.kind !== "source") return null
+  const canvas = readCanvasSourceManifest(capability.manifest?.canvas)
+  if (!canvas || canvas.catalogId !== capability.id) return null
+
+  return {
+    id: canvas.catalogId,
+    idPrefix: canvas.idPrefix,
+    label: canvas.label,
+    description: canvas.description,
+    category: canvas.category,
+    profile: "intelligence",
+    kind: "source",
+    capability: "fetch",
+    icon: canvas.icon,
+    color: canvas.color,
+    adapter: canvas.adapter.id,
+    requiredAdapters: [canvas.adapter],
+    params: canvas.params,
+    runtimeCapability: capability,
+    keywords: canvas.keywords,
+  }
+}
+
+function readCanvasSourceManifest(value: unknown): CanvasSourceManifest | null {
+  if (!isRecord(value) || value.node !== true) return null
+  const adapter = value.adapter
+  const params = value.params
+  const keywords = value.keywords
+  if (
+    typeof value.catalogId !== "string"
+    || typeof value.idPrefix !== "string"
+    || typeof value.label !== "string"
+    || typeof value.description !== "string"
+    || value.category !== "source"
+    || typeof value.icon !== "string"
+    || typeof value.color !== "string"
+    || !Array.isArray(keywords)
+    || !keywords.every((keyword) => typeof keyword === "string")
+    || !isAdapterBinding(adapter)
+    || !isRecord(params)
+  ) return null
+
+  return {
+    catalogId: value.catalogId,
+    idPrefix: value.idPrefix,
+    label: value.label,
+    description: value.description,
+    category: value.category,
+    icon: value.icon,
+    color: value.color,
+    keywords,
+    adapter,
+    params,
+  }
+}
+
+function isAdapterBinding(value: unknown): value is AdapterBinding {
+  return isRecord(value)
+    && typeof value.id === "string"
+    && value.type === "source"
+    && typeof value.provider === "string"
+    && ["fixture", "mock", "webhook", "live"].includes(String(value.mode))
+    && isRecord(value.config)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
 }
 
 export function createWorkflowNodeFromCatalog(

--- a/frontend/lib/workflow/runtime-bridge.ts
+++ b/frontend/lib/workflow/runtime-bridge.ts
@@ -1,6 +1,8 @@
 import type { WorkflowNode, WorkflowNodeData } from "@/lib/flow/types"
 import type { WorkflowCompileError, WorkflowCompileResponse } from "./backend-compile"
 import type { WorkflowOpenCLIHDATraceDispatchItem, WorkflowOpenCLIHDATraceResponse } from "./backend-opencli-hda-trace"
+import type { WorkflowEvidenceBatchSummary, WorkflowEvidenceProjection } from "./backend-runs"
+import { applyEvidenceWorkbenchNodeState } from "./evidence-workbench"
 
 export type WorkflowRuntimeBridgePreview = {
   compile?: WorkflowCompileResponse | null
@@ -119,6 +121,15 @@ export function applyRuntimeNodePatches(nodes: WorkflowNode[], patches: Workflow
       },
     }
   })
+}
+
+export function applyEvidenceBatchRuntimePatches(
+  nodes: WorkflowNode[],
+  edges: import("@/lib/flow/types").WorkflowEdge[],
+  projection: WorkflowEvidenceProjection,
+  batches: WorkflowEvidenceBatchSummary[],
+): { nodes: WorkflowNode[]; edges: import("@/lib/flow/types").WorkflowEdge[] } {
+  return applyEvidenceWorkbenchNodeState(nodes, edges, projection, batches)
 }
 
 function errorPatch(error: WorkflowCompileError): Partial<WorkflowNodeData> {

--- a/frontend/lib/workflow/use-workflow-capabilities.ts
+++ b/frontend/lib/workflow/use-workflow-capabilities.ts
@@ -2,10 +2,63 @@
 
 import { useEffect, useState } from "react"
 import { fetchWorkflowCapabilities } from "./backend-capabilities"
-import type { WorkflowCapabilitiesResponse } from "./capabilities"
+import type {
+  WorkflowCapabilitiesResponse,
+  WorkflowRuntimeCapability,
+} from "./capabilities"
+
+const CANVAS_SOURCE_CHANNELS = new Set([
+  "opencli",
+  "web_scraper",
+  "api",
+  "rss",
+  "cli",
+  "skill",
+  "crawl4ai",
+])
 
 let cachedCapabilities: WorkflowCapabilitiesResponse | null = null
 let inFlight: Promise<WorkflowCapabilitiesResponse> | null = null
+
+export function projectCanvasSourceCapabilities(
+  capabilities: WorkflowCapabilitiesResponse,
+): WorkflowCapabilitiesResponse {
+  const catalog = new Map(capabilities.catalog.map((item) => [item.id, item]))
+  for (const channel of capabilities.channels) {
+    if (!channel.channelType || !CANVAS_SOURCE_CHANNELS.has(channel.channelType)) continue
+    const catalogId = `intelligence.source.channel.${channel.channelType}`
+    if (!catalog.has(catalogId)) {
+      const source = canvasSourceCapability(channel)
+      catalog.set(source.id, source)
+    }
+  }
+  return { ...capabilities, catalog: Array.from(catalog.values()) }
+}
+
+function canvasSourceCapability(
+  channel: WorkflowRuntimeCapability,
+): WorkflowRuntimeCapability {
+  const manifestCanvas = readRecord(channel.manifest?.canvas)
+  const catalogId = readString(manifestCanvas?.catalogId)
+    ?? `intelligence.source.channel.${channel.channelType}`
+  return {
+    ...channel,
+    id: catalogId,
+    label: readString(manifestCanvas?.label) ?? channel.label,
+    surface: "catalog",
+    tags: Array.from(new Set([...channel.tags, "catalog"])),
+  }
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null
+}
 
 export function useWorkflowCapabilities(enabled = true) {
   const [capabilities, setCapabilities] = useState<WorkflowCapabilitiesResponse | null>(
@@ -20,9 +73,10 @@ export function useWorkflowCapabilities(enabled = true) {
     inFlight = request
     request
       .then((value) => {
-        cachedCapabilities = value
+        const projected = projectCanvasSourceCapabilities(value)
+        cachedCapabilities = projected
         if (!cancelled) {
-          setCapabilities(value)
+          setCapabilities(projected)
           setError(null)
         }
       })

--- a/tests/integration/test_evidence_projection_api.py
+++ b/tests/integration/test_evidence_projection_api.py
@@ -1,0 +1,380 @@
+"""HTTP-seam tests for the EvidenceBatch projection API."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.workflow.opencli_hda_tracer import _RUNS
+from tests.integration.test_workflow_opencli_hda_trace_api import (
+    _multi_source_opencli_hda_project,
+)
+
+
+def _native_first_loop_project() -> dict:
+    """Mirror the proven native-first-loop fixture used in issue 06 tests.
+
+    The shape (source -> normalize -> merge -> accept -> record-sink) is the
+    only one that exercises both batch refs and record-sink persistence
+    without compile errors, so we reuse it for projection coverage.
+    """
+
+    return {
+        "id": "wf-evidence-projection",
+        "name": "Evidence projection fixture",
+        "profile": "intelligence",
+        "version": 1,
+        "nodes": [
+            {
+                "id": "source-bilibili",
+                "kind": "source",
+                "capability": "fetch",
+                "adapter": "opencli-bilibili",
+                "params": {
+                    "site": "bilibili",
+                    "command": "search",
+                    "fixtureItems": [
+                        {
+                            "title": "Bilibili AI video",
+                            "url": "https://www.bilibili.com/video/ai",
+                            "content": "AI video update",
+                        }
+                    ],
+                },
+                "ui": {"catalogId": "intelligence.source.opencli-slot"},
+            },
+            {
+                "id": "source-xhs",
+                "kind": "source",
+                "capability": "fetch",
+                "adapter": "opencli-xhs",
+                "params": {
+                    "site": "xiaohongshu",
+                    "command": "search",
+                    "fixtureItems": [
+                        {
+                            "title": "XHS AI note",
+                            "url": "https://www.xiaohongshu.com/explore/ai",
+                            "content": "AI note update",
+                        }
+                    ],
+                },
+                "ui": {"catalogId": "intelligence.source.opencli-slot"},
+            },
+            {
+                "id": "normalize-bilibili",
+                "kind": "agent",
+                "capability": "normalize",
+                "params": {"language": "zh-CN", "preserveSourceRefs": True},
+                "ui": {"catalogId": "intelligence.processing.normalize"},
+            },
+            {
+                "id": "normalize-xhs",
+                "kind": "agent",
+                "capability": "normalize",
+                "params": {"language": "zh-CN", "preserveSourceRefs": True},
+                "ui": {"catalogId": "intelligence.processing.normalize"},
+            },
+            {
+                "id": "merge-candidates",
+                "kind": "flow",
+                "capability": "merge",
+                "params": {
+                    "strategy": "concat",
+                    "preserveLineage": True,
+                    "inputType": "recordCandidate[]",
+                    "outputType": "recordCandidate[]",
+                },
+                "ui": {"catalogId": "intelligence.flow.merge"},
+            },
+            {
+                "id": "accept-records",
+                "kind": "control",
+                "capability": "accept",
+                "params": {
+                    "mode": "automatic_with_review",
+                    "schema": "record.v1",
+                    "dedupe": "required",
+                    "lineageRequired": True,
+                    "minQuality": 0,
+                },
+                "ui": {"catalogId": "intelligence.control.record-acceptance"},
+            },
+            {
+                "id": "record-sink",
+                "kind": "sink",
+                "capability": "store",
+                "params": {
+                    "target": "records",
+                    "writeMode": "append",
+                    "preserveLineage": True,
+                },
+                "ui": {"catalogId": "intelligence.sink.records"},
+            },
+        ],
+        "edges": [
+            {
+                "id": "e-source1-normalize",
+                "source": "source-bilibili",
+                "target": "normalize-bilibili",
+            },
+            {
+                "id": "e-source2-normalize",
+                "source": "source-xhs",
+                "target": "normalize-xhs",
+            },
+            {
+                "id": "e-normalize1-merge",
+                "source": "normalize-bilibili",
+                "target": "merge-candidates",
+                "sourcePort": "out",
+                "targetPort": "in1",
+            },
+            {
+                "id": "e-normalize2-merge",
+                "source": "normalize-xhs",
+                "target": "merge-candidates",
+                "sourcePort": "out",
+                "targetPort": "in2",
+            },
+            {
+                "id": "e-merge-accept",
+                "source": "merge-candidates",
+                "target": "accept-records",
+                "sourcePort": "out",
+                "targetPort": "candidates",
+            },
+            {
+                "id": "e-accept-sink",
+                "source": "accept-records",
+                "target": "record-sink",
+                "sourcePort": "records",
+                "targetPort": "records",
+            },
+        ],
+        "adapters": [
+            {
+                "id": "opencli-bilibili",
+                "type": "source",
+                "provider": "opencli",
+                "mode": "live",
+                "config": {"channel": "opencli"},
+            },
+            {
+                "id": "opencli-xhs",
+                "type": "source",
+                "provider": "opencli",
+                "mode": "live",
+                "config": {"channel": "opencli"},
+            },
+        ],
+        "agentPermissions": {
+            "canFetchNetwork": True,
+            "canSendNotifications": False,
+            "canWriteInbox": True,
+            "allowedDomains": ["bilibili.com", "xiaohongshu.com"],
+        },
+    }
+
+
+def _opencli_hda_project() -> dict:
+    """Project fixture that emits real batch_ready events.
+
+    The Multi Source OpenCLI HDA path is what actually produces batch refs at
+    runtime, so we reuse the proven fixture from issue 06 to exercise the
+    batch projection surface.
+    """
+
+    project = _multi_source_opencli_hda_project()
+    project["id"] = "wf-evidence-opencli-hda"
+    return project
+
+
+@pytest.mark.asyncio
+async def test_evidence_batches_list_pagination_and_filter(client):
+    start = await client.post(
+        "/api/v1/workflows/runs",
+        json={
+            "project": _opencli_hda_project(),
+            "packageNodeId": "multi-source-opencli",
+            "runId": "run-evidence-list",
+            "traceId": "trace-evidence-list",
+        },
+    )
+    assert start.status_code == 202
+    assert start.json()["data"]["runId"] == "run-evidence-list"
+    _RUNS.pop("run-evidence-list", None)
+
+    response = await client.get(
+        "/api/v1/workflows/runs/run-evidence-list/evidence-batches",
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["runId"] == "run-evidence-list"
+    assert len(payload["batches"]) >= 1
+    sample = payload["batches"][0]
+    assert sample["runId"] == "run-evidence-list"
+    assert sample["nodeId"]
+    assert sample["batchId"]
+    assert sample["status"] in {"ready", "ingested", "partial"}
+    assert sample["traceId"] == "trace-evidence-list"
+    assert sample["manifestUri"].startswith(
+        f"/api/v1/workflows/runs/run-evidence-list/batches/{sample['batchId']}"
+    )
+    assert sample["odpRef"].startswith(
+        f"odp://workflow-runs/run-evidence-list/nodes/{sample['nodeId']}"
+    )
+
+    bili_only = await client.get(
+        "/api/v1/workflows/runs/run-evidence-list/evidence-batches",
+        params={"nodeId": "multi-source-opencli::source-bilibili"},
+    )
+    bili_payload = bili_only.json()["data"]
+    assert bili_payload["runId"] == "run-evidence-list"
+    assert {batch["nodeId"] for batch in bili_payload["batches"]} == {
+        "multi-source-opencli::source-bilibili"
+    }
+
+    paged = await client.get(
+        "/api/v1/workflows/runs/run-evidence-list/evidence-batches",
+        params={"limit": 1},
+    )
+    page = paged.json()["data"]
+    assert len(page["batches"]) == 1
+    assert page["nextCursor"] == page["batches"][0]["batchId"]
+
+    next_page = await client.get(
+        "/api/v1/workflows/runs/run-evidence-list/evidence-batches",
+        params={"limit": 1, "cursor": page["nextCursor"]},
+    )
+    next_payload = next_page.json()["data"]
+    if next_payload["batches"]:
+        assert next_payload["batches"][0]["batchId"] != page["batches"][0]["batchId"]
+
+
+@pytest.mark.asyncio
+async def test_evidence_batches_returns_404_for_unknown_run(client):
+    response = await client.get(
+        "/api/v1/workflows/runs/missing-run/evidence-batches",
+    )
+    assert response.status_code == 404
+    detail = response.json().get("detail") or response.json().get("error") or ""
+    assert "not found" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_evidence_batch_detail_links_run_node_and_batch(client):
+    start = await client.post(
+        "/api/v1/workflows/runs",
+        json={
+            "project": _opencli_hda_project(),
+            "packageNodeId": "multi-source-opencli",
+            "runId": "run-evidence-detail",
+            "traceId": "trace-evidence-detail",
+        },
+    )
+    assert start.status_code == 202
+    _RUNS.pop("run-evidence-detail", None)
+
+    list_response = await client.get(
+        "/api/v1/workflows/runs/run-evidence-detail/evidence-batches",
+    )
+    batches = list_response.json()["data"]["batches"]
+    assert batches, "fixture must produce at least one batch"
+    target = batches[0]
+    batch_id = target["batchId"]
+
+    detail = await client.get(
+        f"/api/v1/workflows/runs/run-evidence-detail/evidence-batches/{batch_id}",
+    )
+    assert detail.status_code == 200
+    detail_payload = detail.json()["data"]
+    assert detail_payload["runId"] == "run-evidence-detail"
+    assert detail_payload["batch"]["batchId"] == batch_id
+    assert detail_payload["manifestUri"] == target["manifestUri"]
+    assert detail_payload["odpRef"] == target["odpRef"]
+    assert detail_payload["recordCount"] == target["recordCount"]
+    assert detail_payload["itemCount"] == target["itemCount"]
+    assert detail_payload["sourceCoverage"], "source coverage must be projected"
+    coverage_groups = {entry["sourceGroup"] for entry in detail_payload["sourceCoverage"]}
+    assert target["sourceGroup"] in coverage_groups
+
+    missing = await client.get(
+        "/api/v1/workflows/runs/run-evidence-detail/evidence-batches/not-a-real-batch",
+    )
+    assert missing.status_code == 404
+    detail = missing.json().get("detail") or missing.json().get("error") or ""
+    assert "not found" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_evidence_run_projection_with_includes(client):
+    start = await client.post(
+        "/api/v1/workflows/runs",
+        json={
+            "project": _opencli_hda_project(),
+            "packageNodeId": "multi-source-opencli",
+            "runId": "run-evidence-projection",
+            "traceId": "trace-evidence-projection",
+        },
+    )
+    assert start.status_code == 202
+    _RUNS.pop("run-evidence-projection", None)
+
+    projection = await client.get(
+        "/api/v1/workflows/runs/run-evidence-projection/projection",
+        params={"include": "clusters,missingSources,summaries,conflicts"},
+    )
+    assert projection.status_code == 200
+    body = projection.json()["data"]
+    assert body["runId"] == "run-evidence-projection"
+    assert body["status"] in {"completed", "partial", "running", "queued"}
+    assert body["valid"] is True
+    assert body["nodes"]
+    assert body["artifacts"], "artifacts must include manifest/trace refs"
+    assert body["batches"]
+    assert body["clusters"], "clusters must be projected when requested"
+    for cluster in body["clusters"]:
+        assert cluster["clusterId"]
+        assert cluster["sourceGroups"], "cluster must keep source group refs"
+    assert body["summaries"], "summaries must be projected for completed runs"
+    assert all(
+        entry.get("code") for entry in body["missingSources"]
+    ), "missing sources must carry a stable code when present"
+
+    bad_include = await client.get(
+        "/api/v1/workflows/runs/run-evidence-projection/projection",
+        params={"include": "definitely-not-a-section"},
+    )
+    assert bad_include.status_code == 400
+    detail = bad_include.json().get("detail") or bad_include.json().get("error") or ""
+    assert "include" in detail.lower()
+
+    missing_run = await client.get(
+        "/api/v1/workflows/runs/missing-run/projection",
+    )
+    assert missing_run.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_evidence_projection_filters_batches_by_node(client):
+    start = await client.post(
+        "/api/v1/workflows/runs",
+        json={
+            "project": _opencli_hda_project(),
+            "packageNodeId": "multi-source-opencli",
+            "runId": "run-evidence-filter",
+            "traceId": "trace-evidence-filter",
+        },
+    )
+    assert start.status_code == 202
+    _RUNS.pop("run-evidence-filter", None)
+
+    empty = await client.get(
+        "/api/v1/workflows/runs/run-evidence-filter/projection",
+        params={"nodeId": "non-existent-node"},
+    )
+    assert empty.status_code == 200
+    body = empty.json()["data"]
+    assert body["runId"] == "run-evidence-filter"
+    assert body["batches"] == []
+    assert body["artifacts"], "trace artifact ref remains even for filtered view"

--- a/tests/integration/test_workflow_capabilities_api.py
+++ b/tests/integration/test_workflow_capabilities_api.py
@@ -110,11 +110,7 @@ async def test_compile_reports_webhook_notify_contract_without_live_delivery(cli
     assert response.status_code == 200
     data = response.json()["data"]
     assert data["valid"] is True
-    node = next(
-        node
-        for node in data["plan"]["runtime"]["nodes"]
-        if node["id"] == "notify-webhook"
-    )
+    node = next(node for node in data["plan"]["runtime"]["nodes"] if node["id"] == "notify-webhook")
     assert node["runtime"]["origin"]["catalog_id"] == "intelligence.output.webhook"
     assert "binding" not in node["runtime"]
     assert node["runtime"]["notifier"]["binding_id"] == "workflow.notifier.webhook.send"
@@ -196,8 +192,7 @@ async def test_workflow_capabilities_project_real_backend_surfaces(client, monke
     assert "canFetchNetwork" in opencli_manifest["permissions"]
     assert "source_output_ingest_available" in opencli_manifest["probes"]
     assert (
-        "frontend_run_event_binding"
-        not in catalog["intelligence.source.opencli-slot"]["missing"]
+        "frontend_run_event_binding" not in catalog["intelligence.source.opencli-slot"]["missing"]
     )
     assert catalog["intelligence.source.pool"]["status"] == "runnable"
     assert catalog["intelligence.source.pool"]["backendAvailable"] is True
@@ -257,12 +252,10 @@ async def test_workflow_capabilities_project_real_backend_surfaces(client, monke
     assert "partial:outputItemCount" in external_tool_manifest["trace"]["events"]
     assert catalog["package.opencli.multi-source-hda"]["status"] == "runnable"
     assert (
-        "frontend_run_event_binding"
-        not in catalog["package.opencli.multi-source-hda"]["missing"]
+        "frontend_run_event_binding" not in catalog["package.opencli.multi-source-hda"]["missing"]
     )
     assert (
-        "typed_demand_input_envelope"
-        not in catalog["package.opencli.multi-source-hda"]["missing"]
+        "typed_demand_input_envelope" not in catalog["package.opencli.multi-source-hda"]["missing"]
     )
     assert catalog["intelligence.output.webhook"]["status"] == "blocked"
     assert catalog["intelligence.output.webhook"]["backendAvailable"] is True
@@ -281,9 +274,8 @@ async def test_workflow_capabilities_project_real_backend_surfaces(client, monke
     ]
 
     channels = {item["channelType"]: item for item in data["channels"]}
-    assert set(channels) == {
+    canvas_channel_types = {
         "api",
-        "browser_act",
         "cli",
         "crawl4ai",
         "opencli",
@@ -291,11 +283,46 @@ async def test_workflow_capabilities_project_real_backend_surfaces(client, monke
         "skill",
         "web_scraper",
     }
+    assert canvas_channel_types.issubset(channels)
     assert channels["opencli"]["status"] == "runnable"
     assert channels["opencli"]["backendAvailable"] is True
+    assert channels["opencli"]["runtimeBinding"] == "iii.collector-opencli.snapshot"
     assert channels["rss"]["status"] == "blocked"
     assert channels["rss"]["backendAvailable"] is True
-    assert "canvas_source_projection" in channels["rss"]["missing"]
+    assert channels["rss"]["runtimeBinding"] == "workflow.source.fetch"
+    assert "live_source_executor" in channels["rss"]["missing"]
+    assert "channel_config.feed_url" in channels["rss"]["missing"]
+    assert channels["rss"]["reason"]
+
+    canvas_sources = {
+        item["channelType"]: item
+        for item in data["catalog"]
+        if item["id"].startswith("intelligence.source.channel.")
+    }
+    assert set(canvas_sources) == canvas_channel_types
+    for channel_type, source in canvas_sources.items():
+        channel = channels[channel_type]
+        assert source["status"] == channel["status"]
+        assert source["reason"] == channel["reason"]
+        assert source["missing"] == channel["missing"]
+        assert source["runtimeBinding"] == channel["runtimeBinding"]
+        assert source["kind"] == "source"
+        assert source["capability"] == "fetch"
+        assert source["manifest"]["schema"] == "capability.source.channel.v1"
+        assert source["manifest"]["channel"]["type"] == channel_type
+        assert source["manifest"]["canvas"]["node"] is True
+        assert source["manifest"]["canvas"]["catalogId"] == source["id"]
+        assert source["manifest"]["canvas"]["adapter"]["provider"] == channel_type
+        assert source["manifest"]["canvas"]["params"]["channelType"] == channel_type
+
+    assert canvas_sources["skill"]["manifest"]["channel"]["capabilities"]["sessionAffinity"] is True
+    assert "browser_session_resource" in canvas_sources["skill"]["missing"]
+    assert canvas_sources["rss"]["manifest"]["channel"]["capabilities"]["incremental"] is True
+    assert "cli_binary_allowlist" in canvas_sources["cli"]["missing"]
+    assert canvas_sources["crawl4ai"]["reason"]
+    assert channels["browser_act"]["status"] == "blocked"
+    assert channels["browser_act"]["manifest"] == {}
+    assert "browser_act" not in canvas_sources
 
     notifiers = {item["notifierType"]: item for item in data["notifiers"]}
     assert "webhook" in notifiers
@@ -328,9 +355,7 @@ async def test_workflow_capabilities_project_real_backend_surfaces(client, monke
     assert adapter_registry["backendAvailable"] is True
     assert adapter_registry["runtimeBinding"] == "iii.collector-opencli.snapshot"
     assert adapter_registry["manifest"]["canvas"]["node"] is False
-    assert adapter_registry["manifest"]["endpoint"] == (
-        "/api/v1/workflows/opencli-adapter-nodes"
-    )
+    assert adapter_registry["manifest"]["endpoint"] == ("/api/v1/workflows/opencli-adapter-nodes")
     assert adapter_registry["manifest"]["summary"]["total"] == 3
     assert adapter_registry["manifest"]["materialization"]["write"] == (
         "external.tool.capability with review"
@@ -341,9 +366,7 @@ async def test_workflow_capabilities_project_real_backend_surfaces(client, monke
     assert tool_resource["runtimeBinding"] == "workflow.external-tool.capability"
     assert tool_resource["manifest"]["toolCapability"]["id"] == "tool.search.fixture"
     assert tool_resource["manifest"]["toolCapability"]["executor"]["mode"] == "fixture"
-    realtime_resource = resources[
-        "resource.tool-capability.tool.realtime.stream.subscribe"
-    ]
+    realtime_resource = resources["resource.tool-capability.tool.realtime.stream.subscribe"]
     assert realtime_resource["status"] == "runnable"
     assert realtime_resource["runtimeBinding"] == "workflow.external-tool.capability"
     assert realtime_resource["manifest"]["toolCapability"]["id"] == (
@@ -374,18 +397,14 @@ def test_opencli_adapter_nodes_classify_manifest_entries(monkeypatch):
     assert twitter_search.status == "blocked"
     assert twitter_search.catalogId == "intelligence.source.opencli-slot"
     assert twitter_search.requiredArgs == ["query"]
-    assert twitter_search.manifest["canvas"]["materialization"] == (
-        "source_slot_requires_params"
-    )
+    assert twitter_search.manifest["canvas"]["materialization"] == ("source_slot_requires_params")
     assert twitter_search.manifest["canvas"]["positionalRequiredArgs"] == ["query"]
 
     twitter_post = nodes["opencli.adapter.twitter.post"]
     assert twitter_post.status == "blocked"
     assert twitter_post.catalogId == "external.tool.capability"
     assert twitter_post.manifest["canvas"]["node"] is False
-    assert twitter_post.manifest["canvas"]["materialization"] == (
-        "tool_capability_review_required"
-    )
+    assert twitter_post.manifest["canvas"]["materialization"] == ("tool_capability_review_required")
     assert response.summary == {
         "total": 3,
         "sites": 2,
@@ -430,9 +449,7 @@ async def test_workflow_tool_capabilities_register_opencli_tool_bindings(client)
     assert fixture_tool["executor"]["mode"] == "fixture"
     assert fixture_tool["inputPorts"] == [{"name": "in", "type": "unknown"}]
     assert fixture_tool["outputPorts"] == [{"name": "out", "type": "unknown"}]
-    assert fixture_tool["manifest"]["runtime"]["binding"] == (
-        "workflow.external-tool.capability"
-    )
+    assert fixture_tool["manifest"]["runtime"]["binding"] == ("workflow.external-tool.capability")
     realtime_ids = {
         "tool.realtime.stream.subscribe",
         "tool.realtime.event.normalize",

--- a/tests/unit/test_workflow_capability_projection.py
+++ b/tests/unit/test_workflow_capability_projection.py
@@ -1,0 +1,69 @@
+from backend.channels.base import Capabilities
+from backend.schemas.workflow import WorkflowRuntimeCapability
+from backend.workflow import capability_projection
+
+
+class _StubChannel:
+    def __init__(self, capabilities: Capabilities) -> None:
+        self.capabilities = capabilities
+
+
+def test_canvas_source_projection_covers_seven_channels(monkeypatch) -> None:
+    channel_capabilities = {
+        channel_type: Capabilities(
+            incremental=channel_type == "rss",
+            session_affinity=channel_type in {"opencli", "skill"},
+        )
+        for channel_type in capability_projection.CANVAS_SOURCE_CHANNEL_TYPES
+    }
+    monkeypatch.setattr(
+        capability_projection,
+        "get_channel",
+        lambda channel_type: _StubChannel(channel_capabilities[channel_type]),
+    )
+    monkeypatch.setattr(
+        capability_projection,
+        "list_channel_types",
+        lambda: [*capability_projection.CANVAS_SOURCE_CHANNEL_TYPES, "browser_act"],
+    )
+
+    channels = {item.channelType: item for item in capability_projection._channel_capabilities()}
+    sources = {
+        item.channelType: item
+        for item in capability_projection._canvas_source_catalog_capabilities()
+    }
+
+    assert set(sources) == set(capability_projection.CANVAS_SOURCE_CHANNEL_TYPES)
+    assert channels["opencli"].status == "runnable"
+    assert channels["opencli"].runtimeBinding == "iii.collector-opencli.snapshot"
+    for channel_type in set(sources) - {"opencli"}:
+        source = sources[channel_type]
+        assert source.status == "blocked"
+        assert source.runtimeBinding == "workflow.source.fetch"
+        assert source.reason
+        assert "live_source_executor" in source.missing
+        assert source.manifest["canvas"]["node"] is True
+        assert source.manifest["canvas"]["adapter"]["provider"] == channel_type
+        assert source.manifest["canvas"]["params"]["channelType"] == channel_type
+
+    assert sources["rss"].manifest["channel"]["capabilities"]["incremental"] is True
+    assert "browser_session_resource" in sources["skill"].missing
+    assert "cli_binary_allowlist" in sources["cli"].missing
+    assert channels["browser_act"].manifest == {}
+    assert "browser_act" not in sources
+
+
+def test_blocked_channel_reason_is_preserved_on_catalog_projection(monkeypatch) -> None:
+    monkeypatch.setattr(
+        capability_projection,
+        "get_channel",
+        lambda _channel_type: _StubChannel(Capabilities()),
+    )
+
+    channel = capability_projection._channel_capability("api")
+    source = capability_projection._channel_capability("api", surface="catalog")
+
+    assert isinstance(source, WorkflowRuntimeCapability)
+    assert source.reason == channel.reason
+    assert source.missing == channel.missing
+    assert source.manifest["channel"]["requiredConfig"] == ["base_url", "endpoint"]


### PR DESCRIPTION
## Summary

Fixes 9 failing tests across 5 test files in the automation pipeline feature.

### Changes

**`intent_parser.py`** — moved `finance` before `news` in `TOPIC_KIND_PATTERNS` so compound "财经新闻" matches finance; added `trending` to hot-posts patterns.

**`runtime_contracts.py`** — added `iii.collector-rss.snapshot` and `iii.collector-api.snapshot` contracts so RSS/API channel bindings get their runtime I/O contract attached at compile time.

**`capability_projection.py`** — wired RSS/API channel source predicates to `resolve_channel_source_binding`.

**`runtime_resources.py`** — added `SourceResourceRequirement`/`SourceResourceResolution` types and `resolve_source_resources()` for Canvas source node resource preflight.

**`webhook_delivery.py`** — added `project_evidence_batch`, `resolve_webhook_url`, `assert_send_permission`, `execute_workflow_notifier_fanout`; fixed test manifest key references (`inputShape`/`outputShape`/`eventShape`).

**`demand_assembler.py`** — integrated intent_parser for structured source/channel resolution; emits blocked source nodes for non-opencli channels with `request_missing_capability` operations; attaches Cron Schedule nodes for frequency hints.

### Test results

```
77 passed, 0 failed
```

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
