### PR TITLE
fix(workflow): unblock draft compile previews from plan-IR strictness

### DIFF
--- a/backend/plan_ir/validation.py
+++ b/backend/plan_ir/validation.py
@@ -204,7 +204,15 @@ def _check_orphan_merges(
 ) -> list[PlanValidationError]:
     """A merge node exists to combine two or more upstream branches — one
     with fewer than two connected inputs is not merging anything and is
-    reported as orphaned (PRD story 23 / issue 01 acceptance criterion)."""
+    reported as orphaned (PRD story 23 / issue 01 acceptance criterion).
+
+    Draft graphs are exempt: compile previews, external-runtime imports and
+    demand drafts (all compiled with ``PlanGraph(draft=True)``) legitimately
+    hold partially wired merges the operator finishes in the studio. The
+    strict rule keeps gating non-draft validation (``POST /plan-ir/validate``
+    with ``draft=False`` and future publish gates)."""
+    if plan.draft:
+        return []
     errors: list[PlanValidationError] = []
     incoming_count: dict[str, int] = {n.id: 0 for n in plan.nodes}
     for e in plan.edges:
@@ -233,7 +241,10 @@ def _check_port_type_mismatches(
     plan: PlanGraph, nodes_by_id: dict[str, PlanNode]
 ) -> list[PlanValidationError]:
     """An edge's source-port type and target-port type must match, unless
-    either side is declared "any". Dangling edges (already reported by
+    either side is declared "any" or "unknown" — the same wildcard semantics
+    the workflow compiler's own edge check uses (``_types_compatible``), so
+    imported ``external.tool.capability`` nodes (fallback port type
+    "unknown") stay connectable. Dangling edges (already reported by
     ``_check_dangling_edges``) are skipped here to avoid duplicate noise."""
     errors: list[PlanValidationError] = []
     for e in plan.edges:
@@ -245,7 +256,9 @@ def _check_port_type_mismatches(
         tgt_port = next((p for p in tgt.inputs if p.name == e.target_port), None)
         if src_port is None or tgt_port is None:
             continue  # already reported as unknown_source_port / unknown_target_port
-        if src_port.type != tgt_port.type and "any" not in (src_port.type, tgt_port.type):
+        if src_port.type != tgt_port.type and not (
+            {"any", "unknown"} & {src_port.type, tgt_port.type}
+        ):
             errors.append(
                 PlanValidationError(
                     code="port_type_mismatch",

--- a/backend/workflow/compiler.py
+++ b/backend/workflow/compiler.py
@@ -84,7 +84,11 @@ _PORT_CONTRACTS: dict[str, tuple[list[_PortContract], list[_PortContract]]] = {
         [_PortContract("out", "output", "storedItems[]", required=False)],
     ),
     "intelligence.output.inbox": (
-        [_PortContract("in", "input", "items[]")],
+        # recordCandidate[] like its kind-level fallback (kind=inbox/sink +
+        # store) and the sibling collection-result contract — the old
+        # items[] here predated the recordCandidate[] type chain and made
+        # normalize -> inbox unconnectable.
+        [_PortContract("in", "input", "recordCandidate[]")],
         [_PortContract("out", "output", "storedItems[]", required=False)],
     ),
     "intelligence.output.webhook": (


### PR DESCRIPTION
## What

Integration 5 个红测 (patch / langgraph·langchain import / demand-draft) 一个根因簇: **draft 编译预览被按"已定稿工作流"的 canonical 校验卡死**。

1. `plan_ir/validation`: `orphan_merge` 对 draft 图豁免 — 导入/需求草稿合法存在"只接了一条入边的 merge", 操作员在 studio 里补完; 非 draft 校验 (`POST /plan-ir/validate`, publish 关口) 严格规则不变
2. `plan_ir/validation`: 端口类型检查把 `unknown` 当通配, 与 compiler 自己的 `_types_compatible` 语义对齐 — `external.tool.capability` 节点 (fallback 型 `unknown`) 恢复可连
3. `compiler`: `intelligence.output.inbox` 入口 `items[]` → `recordCandidate[]` — 与 kind 级 fallback 和姊妹 `collection-result` 对齐, 旧型号导致 normalize → inbox 永远连不上

## Test

- tests/integration: **383 passed, 5 skipped** (修前 378 过 5 红)
- tests/unit + skills: 1336 passed, 19 fail 均为已知 .env token 泄漏集 (PR #17 的 conftest 隔离修复负责), 本 PR 零新增
- MVP 意义: langgraph/langchain 导入 → studio 编辑 → 编译预览链路首次全通

## 关联

- 挂靠账本: docs/BUG-TRIAGE-20260718.md P1 (见 PR #17)
