### PR TITLE
feat(frontend): 统一 Dify 式插件中心 — RSS 源库+模板收口 [epic #25]

### DIFF
--- a/frontend/app/(app)/plugins/page.tsx
+++ b/frontend/app/(app)/plugins/page.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { motion } from 'motion/react'
+import { LibraryBig } from 'lucide-react'
+
+import { Ripple } from '@/components/motion/ripple'
+import { RssCatalogImportDialog } from '@/components/plugins/rss-catalog-import-dialog'
+import { TemplateCatalog } from '@/components/plugins/template-catalog'
+import { EmptyState } from '@/components/shell/data-states'
+import { PageContainer } from '@/components/shell/page-container'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+type PluginSubtype = 'datasource' | 'template' | 'tool' | 'agent' | 'trigger' | 'extension'
+
+const SUBTYPES: { key: PluginSubtype; label: string }[] = [
+  { key: 'datasource', label: '源库' },
+  { key: 'template', label: '模板' },
+  { key: 'tool', label: '工具' },
+  { key: 'agent', label: 'Agent' },
+  { key: 'trigger', label: '触发器' },
+  { key: 'extension', label: '扩展' },
+]
+
+const PLACEHOLDER_DESCRIPTION: Record<Exclude<PluginSubtype, 'datasource' | 'template'>, string> = {
+  tool: '连接外部工具与 API，扩展工作流中可调用的能力。',
+  agent: '安装预置的分析与判断 Agent，用于富化采集到的数据。',
+  trigger: '安装可复用的触发规则，按事件或计划驱动自动化运行。',
+  extension: '扩展控制台能力的其他插件与集成。',
+}
+
+function isPluginSubtype(value: string | null): value is PluginSubtype {
+  return SUBTYPES.some((subtype) => subtype.key === value)
+}
+
+/**
+ * Segmented subtype switcher, styled to match `RouteTabs`
+ * (components/shell/route-tabs.tsx) — but this hub is a single page with
+ * subtype *content*, not sibling routes, so `RouteTabs` itself (which derives
+ * its active state from `usePathname()`) doesn't apply here. State lives in
+ * the `?type=` search param instead, so a tab is still linkable/shareable.
+ */
+function PluginTypeTabs({ active, onSelect }: { active: PluginSubtype; onSelect: (next: PluginSubtype) => void }) {
+  return (
+    <nav aria-label="插件类型" className="inline-flex w-fit items-center gap-1 rounded-full bg-muted p-1">
+      {SUBTYPES.map((subtype) => {
+        const isActive = subtype.key === active
+        return (
+          <button
+            key={subtype.key}
+            type="button"
+            aria-current={isActive ? 'page' : undefined}
+            onClick={() => onSelect(subtype.key)}
+            className={cn(
+              'relative overflow-hidden rounded-full px-4 py-1.5 text-sm font-medium transition-colors',
+              isActive ? 'text-primary-foreground' : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {isActive ? (
+              <motion.span
+                layoutId="plugin-hub-tab-pill"
+                className="absolute inset-0 rounded-full bg-primary"
+                transition={{ type: 'spring', stiffness: 460, damping: 38, mass: 0.6 }}
+              />
+            ) : null}
+            <span className="relative">{subtype.label}</span>
+            <Ripple />
+          </button>
+        )
+      })}
+    </nav>
+  )
+}
+
+function DatasourceLibraryTab() {
+  const [importOpen, setImportOpen] = useState(false)
+  return (
+    <>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <button
+          type="button"
+          onClick={() => setImportOpen(true)}
+          className="group flex min-h-48 flex-col rounded-md border bg-background/60 p-4 text-left transition-[border-color,background-color,transform] hover:-translate-y-0.5 hover:border-foreground/25 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        >
+          <div className="flex items-start gap-3">
+            <div className="grid size-10 shrink-0 place-items-center rounded-md border bg-muted/40">
+              <LibraryBig aria-hidden="true" className="size-4.5" />
+            </div>
+            <div className="min-w-0">
+              <h3 className="truncate text-sm font-semibold">RSS 开源源库</h3>
+              <Badge variant="outline" className="mt-1 h-5 px-1.5 text-3xs">
+                数据源
+              </Badge>
+            </div>
+          </div>
+          <p className="mt-3 line-clamp-3 text-xs leading-5 text-muted-foreground">
+            从 GitHub OPML 源包批量导入分类好的 RSS 数据源，导入后默认停用，审核通过再启用采集。
+          </p>
+          <span className="mt-auto border-t pt-3 text-xs font-medium text-foreground">
+            安装 <span aria-hidden="true">→</span>
+          </span>
+        </button>
+      </div>
+      <RssCatalogImportDialog open={importOpen} onOpenChange={setImportOpen} />
+    </>
+  )
+}
+
+export default function PluginHubPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const rawType = searchParams.get('type')
+  const active: PluginSubtype = isPluginSubtype(rawType) ? rawType : 'datasource'
+
+  function selectSubtype(next: PluginSubtype) {
+    const params = new URLSearchParams(searchParams.toString())
+    if (next === 'datasource') params.delete('type')
+    else params.set('type', next)
+    const query = params.toString()
+    router.push(query ? `/plugins?${query}` : '/plugins', { scroll: false })
+  }
+
+  return (
+    <PageContainer
+      eyebrow="Plugin Hub"
+      title="插件中心"
+      description="像应用市场一样浏览、安装和管理可插拔能力——源库、模板、工具、Agent、触发器与扩展统一入口。"
+      tabs={<PluginTypeTabs active={active} onSelect={selectSubtype} />}
+    >
+      {active === 'datasource' ? (
+        <DatasourceLibraryTab />
+      ) : active === 'template' ? (
+        <TemplateCatalog />
+      ) : (
+        <EmptyState title="即将上线" description={PLACEHOLDER_DESCRIPTION[active]} />
+      )}
+    </PageContainer>
+  )
+}

--- a/frontend/app/(app)/sources/page.tsx
+++ b/frontend/app/(app)/sources/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { ChevronRight, Download, ExternalLink, LibraryBig, Play } from 'lucide-react'
+import { ChevronRight, Play } from 'lucide-react'
 import { toast } from 'sonner'
 
 import * as api from '@/lib/api/endpoints'
@@ -17,16 +17,6 @@ import { StatusBadge } from '@/components/shell/status-badge'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import {
   Table,
@@ -48,46 +38,9 @@ const CHANNEL_LABEL: Record<DataSource['channel_type'], string> = {
   browser_act: 'BrowserAct 采集',
 }
 
-const RSS_CATALOG_COMMIT = '3a7a9e28943d28b8acb6d9197fb168a8be5267f6'
-const RSS_CATALOG_BASE =
-  `https://raw.githubusercontent.com/plenaryapp/awesome-rss-feeds/${RSS_CATALOG_COMMIT}/recommended/with_category`
-
-const RSS_CATALOG_PRESETS = [
-  {
-    id: 'business',
-    label: '商业与经济',
-    description: '市场、公司、宏观经济与商业分析',
-    count: 17,
-    url: `${RSS_CATALOG_BASE}/Business%20%26%20Economy.opml`,
-  },
-  {
-    id: 'personal-finance',
-    label: '个人财经',
-    description: '理财、投资、税务与消费金融',
-    count: 30,
-    url: `${RSS_CATALOG_BASE}/Personal%20finance.opml`,
-  },
-  {
-    id: 'news',
-    label: '综合新闻',
-    description: '全球新闻与公共事件',
-    count: 10,
-    url: `${RSS_CATALOG_BASE}/News.opml`,
-  },
-  {
-    id: 'tech',
-    label: '科技',
-    description: '开发、产品、平台与技术产业',
-    count: 28,
-    url: `${RSS_CATALOG_BASE}/Tech.opml`,
-  },
-] as const
-
 export default function SourcesPage() {
   const [enabledFilter, setEnabledFilter] = useState<'all' | 'enabled' | 'disabled'>('all')
   const [page, setPage] = useState(1)
-  const [catalogOpen, setCatalogOpen] = useState(false)
-  const [catalogUrl, setCatalogUrl] = useState<string>(RSS_CATALOG_PRESETS[0].url)
   const queryClient = useQueryClient()
   const params = {
     page,
@@ -115,20 +68,6 @@ export default function SourcesPage() {
     onError: (e: Error) => toast.error(e.message),
   })
 
-  const importCatalog = useMutation({
-    mutationFn: () => api.importRssCatalog(catalogUrl.trim()),
-    onSuccess: (result) => {
-      queryClient.invalidateQueries({ queryKey: ['sources'] })
-      toast.success(
-        `已导入 ${result.created.length} 个 RSS 数据源，跳过 ${result.skipped_existing.length} 个重复项`,
-      )
-      setCatalogOpen(false)
-      setEnabledFilter('disabled')
-      setPage(1)
-    },
-    onError: (e: Error) => toast.error(e.message),
-  })
-
   const sources = data?.data ?? []
   const pagination = data?.meta
 
@@ -139,211 +78,134 @@ export default function SourcesPage() {
   ]
 
   return (
-    <>
-      <PageContainer
-        eyebrow="Automation"
-        title="自动化与 Agent"
-        description="从数据入口、触发调度到 Agent 处理和技能执行，集中管理完整自动化链路。"
-        tabs={<RouteTabs tabs={AUTOMATION_TABS} />}
-        actions={
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            <Button size="sm" className="gap-1.5" onClick={() => setCatalogOpen(true)}>
-              <LibraryBig className="size-3.5" />
-              导入 RSS 源库
-            </Button>
-            <div className="flex items-center gap-1 rounded-md border p-0.5">
-              {filters.map((f) => (
-                <Button
-                  key={f.key}
-                  size="sm"
-                  variant={enabledFilter === f.key ? 'secondary' : 'ghost'}
-                  className="h-7"
-                  onClick={() => {
-                    setEnabledFilter(f.key)
-                    setPage(1)
-                  }}
-                >
-                  {f.label}
-                </Button>
-              ))}
-            </div>
-          </div>
-        }
-      >
-        {isLoading ? (
-          <LoadingState />
-        ) : isError ? (
-          <ErrorState message={(error as Error)?.message} hint={BACKEND_HINT} />
-        ) : sources.length === 0 ? (
-          <EmptyState title="暂无数据源" description="连接后端后，已配置的采集入口将显示在此。" />
-        ) : (
-          <Card className="overflow-hidden py-0">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>名称</TableHead>
-                  <TableHead>渠道</TableHead>
-                  <TableHead>标签</TableHead>
-                  <TableHead>状态</TableHead>
-                  <TableHead>更新时间</TableHead>
-                  <TableHead className="text-right">操作</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sources.map((s) => (
-                  <TableRow key={s.id}>
-                    <TableCell>
-                      <Link
-                        href={`/sources/${s.id}`}
-                        className="group inline-flex items-center gap-1 font-medium hover:text-primary"
-                      >
-                        {s.name}
-                        <ChevronRight className="size-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-                      </Link>
-                      {s.review_required ? (
-                        <Badge variant="destructive" className="ml-2">
-                          待复核
-                        </Badge>
-                      ) : null}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {CHANNEL_LABEL[s.channel_type] ?? s.channel_type}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex flex-wrap gap-1">
-                        {s.tags.slice(0, 3).map((t) => (
-                          <Badge key={t} variant="outline">
-                            {t}
-                          </Badge>
-                        ))}
-                        {s.tags.length === 0 ? <span className="text-muted-foreground">—</span> : null}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <StatusBadge status={s.enabled ? 'enabled' : 'disabled'} />
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">{formatRelative(s.updated_at)}</TableCell>
-                    <TableCell>
-                      <div className="flex items-center justify-end gap-2">
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="h-7 gap-1"
-                          disabled={!s.enabled || trigger.isPending}
-                          onClick={() => trigger.mutate(s.id)}
-                        >
-                          <Play className="size-3.5" />
-                          采集
-                        </Button>
-                        <Switch
-                          checked={s.enabled}
-                          disabled={toggle.isPending}
-                          onCheckedChange={(v) => toggle.mutate({ id: s.id, enabled: v })}
-                          aria-label="启用/停用"
-                        />
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-            {pagination && pagination.pages > 1 ? (
-              <div className="flex items-center justify-between border-t px-4 py-3">
-                <span className="text-sm text-muted-foreground">
-                  共 {pagination.total} 个数据源 · 第 {pagination.page}/{pagination.pages} 页
-                </span>
-                <div className="flex items-center gap-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={pagination.page <= 1}
-                    onClick={() => setPage((current) => Math.max(1, current - 1))}
-                  >
-                    上一页
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={pagination.page >= pagination.pages}
-                    onClick={() => setPage((current) => Math.min(pagination.pages, current + 1))}
-                  >
-                    下一页
-                  </Button>
-                </div>
-              </div>
-            ) : null}
-          </Card>
-        )}
-      </PageContainer>
-
-      <Dialog open={catalogOpen} onOpenChange={setCatalogOpen}>
-        <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>导入开源 RSS 源库</DialogTitle>
-            <DialogDescription>
-              从 GitHub OPML 源包批量创建 RSS 数据源。所有源默认停用，并保留分类和源库出处，审核后再启用。
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="grid gap-3 sm:grid-cols-2">
-            {RSS_CATALOG_PRESETS.map((preset) => {
-              const selected = catalogUrl === preset.url
-              return (
-                <button
-                  key={preset.id}
-                  type="button"
-                  className={`rounded-lg border p-3 text-left transition-colors ${
-                    selected ? 'border-primary bg-primary/5' : 'hover:bg-muted/60'
-                  }`}
-                  onClick={() => setCatalogUrl(preset.url)}
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="font-medium">{preset.label}</span>
-                    <Badge variant={selected ? 'default' : 'secondary'}>{preset.count} 个源</Badge>
-                  </div>
-                  <p className="mt-1 text-sm text-muted-foreground">{preset.description}</p>
-                </button>
-              )
-            })}
-          </div>
-
-          <div className="grid gap-2">
-            <Label htmlFor="rss-catalog-url">GitHub Raw OPML 地址</Label>
-            <Input
-              id="rss-catalog-url"
-              value={catalogUrl}
-              onChange={(event) => setCatalogUrl(event.target.value)}
-              placeholder="https://raw.githubusercontent.com/.../feeds.opml"
-            />
-            <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-              <span>也可以粘贴其他公开 OPML 源库地址，单次上限 2 MB。</span>
-              <Link
-                href="https://github.com/plenaryapp/awesome-rss-feeds"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex shrink-0 items-center gap-1 hover:text-foreground"
-              >
-                查看源库
-                <ExternalLink className="size-3" />
-              </Link>
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setCatalogOpen(false)}>
-              取消
-            </Button>
+    <PageContainer
+      eyebrow="Automation"
+      title="自动化与 Agent"
+      description="从数据入口、触发调度到 Agent 处理和技能执行，集中管理完整自动化链路。"
+      tabs={<RouteTabs tabs={AUTOMATION_TABS} />}
+      actions={
+        <div className="flex items-center gap-1 rounded-md border p-0.5">
+          {filters.map((f) => (
             <Button
-              className="gap-1.5"
-              disabled={!catalogUrl.trim() || importCatalog.isPending}
-              onClick={() => importCatalog.mutate()}
+              key={f.key}
+              size="sm"
+              variant={enabledFilter === f.key ? 'secondary' : 'ghost'}
+              className="h-7"
+              onClick={() => {
+                setEnabledFilter(f.key)
+                setPage(1)
+              }}
             >
-              <Download className="size-3.5" />
-              {importCatalog.isPending ? '正在导入…' : '导入并进入审核'}
+              {f.label}
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+          ))}
+        </div>
+      }
+    >
+      {isLoading ? (
+        <LoadingState />
+      ) : isError ? (
+        <ErrorState message={(error as Error)?.message} hint={BACKEND_HINT} />
+      ) : sources.length === 0 ? (
+        <EmptyState title="暂无数据源" description="连接后端后，已配置的采集入口将显示在此。" />
+      ) : (
+        <Card className="overflow-hidden py-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>名称</TableHead>
+                <TableHead>渠道</TableHead>
+                <TableHead>标签</TableHead>
+                <TableHead>状态</TableHead>
+                <TableHead>更新时间</TableHead>
+                <TableHead className="text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sources.map((s) => (
+                <TableRow key={s.id}>
+                  <TableCell>
+                    <Link
+                      href={`/sources/${s.id}`}
+                      className="group inline-flex items-center gap-1 font-medium hover:text-primary"
+                    >
+                      {s.name}
+                      <ChevronRight className="size-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                    </Link>
+                    {s.review_required ? (
+                      <Badge variant="destructive" className="ml-2">
+                        待复核
+                      </Badge>
+                    ) : null}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {CHANNEL_LABEL[s.channel_type] ?? s.channel_type}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {s.tags.slice(0, 3).map((t) => (
+                        <Badge key={t} variant="outline">
+                          {t}
+                        </Badge>
+                      ))}
+                      {s.tags.length === 0 ? <span className="text-muted-foreground">—</span> : null}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge status={s.enabled ? 'enabled' : 'disabled'} />
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{formatRelative(s.updated_at)}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center justify-end gap-2">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 gap-1"
+                        disabled={!s.enabled || trigger.isPending}
+                        onClick={() => trigger.mutate(s.id)}
+                      >
+                        <Play className="size-3.5" />
+                        采集
+                      </Button>
+                      <Switch
+                        checked={s.enabled}
+                        disabled={toggle.isPending}
+                        onCheckedChange={(v) => toggle.mutate({ id: s.id, enabled: v })}
+                        aria-label="启用/停用"
+                      />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          {pagination && pagination.pages > 1 ? (
+            <div className="flex items-center justify-between border-t px-4 py-3">
+              <span className="text-sm text-muted-foreground">
+                共 {pagination.total} 个数据源 · 第 {pagination.page}/{pagination.pages} 页
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={pagination.page <= 1}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                >
+                  上一页
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={pagination.page >= pagination.pages}
+                  onClick={() => setPage((current) => Math.min(pagination.pages, current + 1))}
+                >
+                  下一页
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </Card>
+      )}
+    </PageContainer>
   )
 }

--- a/frontend/components/plugins/rss-catalog-import-dialog.tsx
+++ b/frontend/components/plugins/rss-catalog-import-dialog.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Download, ExternalLink } from 'lucide-react'
+import { toast } from 'sonner'
+
+import * as api from '@/lib/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+const RSS_CATALOG_COMMIT = '3a7a9e28943d28b8acb6d9197fb168a8be5267f6'
+const RSS_CATALOG_BASE =
+  `https://raw.githubusercontent.com/plenaryapp/awesome-rss-feeds/${RSS_CATALOG_COMMIT}/recommended/with_category`
+
+const RSS_CATALOG_PRESETS = [
+  {
+    id: 'business',
+    label: '商业与经济',
+    description: '市场、公司、宏观经济与商业分析',
+    count: 17,
+    url: `${RSS_CATALOG_BASE}/Business%20%26%20Economy.opml`,
+  },
+  {
+    id: 'personal-finance',
+    label: '个人财经',
+    description: '理财、投资、税务与消费金融',
+    count: 30,
+    url: `${RSS_CATALOG_BASE}/Personal%20finance.opml`,
+  },
+  {
+    id: 'news',
+    label: '综合新闻',
+    description: '全球新闻与公共事件',
+    count: 10,
+    url: `${RSS_CATALOG_BASE}/News.opml`,
+  },
+  {
+    id: 'tech',
+    label: '科技',
+    description: '开发、产品、平台与技术产业',
+    count: 28,
+    url: `${RSS_CATALOG_BASE}/Tech.opml`,
+  },
+] as const
+
+/**
+ * Installs the open-source RSS OPML catalog as disabled data sources.
+ *
+ * Extracted from the old sources/page.tsx "导入 RSS 源库" action — this is a
+ * catalog/install action (Plugin Hub concern), not instance management, so it
+ * now lives under the Plugin Hub's 源库 tab. sources/page.tsx only manages
+ * already-installed data source instances.
+ */
+export function RssCatalogImportDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const [catalogUrl, setCatalogUrl] = useState<string>(RSS_CATALOG_PRESETS[0].url)
+  const queryClient = useQueryClient()
+
+  const importCatalog = useMutation({
+    mutationFn: () => api.importRssCatalog(catalogUrl.trim()),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['sources'] })
+      toast.success(
+        `已导入 ${result.created.length} 个 RSS 数据源，跳过 ${result.skipped_existing.length} 个重复项`,
+      )
+      onOpenChange(false)
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>导入开源 RSS 源库</DialogTitle>
+          <DialogDescription>
+            从 GitHub OPML 源包批量创建 RSS 数据源。所有源默认停用，并保留分类和源库出处，审核后再启用。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {RSS_CATALOG_PRESETS.map((preset) => {
+            const selected = catalogUrl === preset.url
+            return (
+              <button
+                key={preset.id}
+                type="button"
+                className={`rounded-lg border p-3 text-left transition-colors ${
+                  selected ? 'border-primary bg-primary/5' : 'hover:bg-muted/60'
+                }`}
+                onClick={() => setCatalogUrl(preset.url)}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="font-medium">{preset.label}</span>
+                  <Badge variant={selected ? 'default' : 'secondary'}>{preset.count} 个源</Badge>
+                </div>
+                <p className="mt-1 text-sm text-muted-foreground">{preset.description}</p>
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="rss-catalog-url">GitHub Raw OPML 地址</Label>
+          <Input
+            id="rss-catalog-url"
+            value={catalogUrl}
+            onChange={(event) => setCatalogUrl(event.target.value)}
+            placeholder="https://raw.githubusercontent.com/.../feeds.opml"
+          />
+          <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+            <span>也可以粘贴其他公开 OPML 源库地址，单次上限 2 MB。</span>
+            <Link
+              href="https://github.com/plenaryapp/awesome-rss-feeds"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex shrink-0 items-center gap-1 hover:text-foreground"
+            >
+              查看源库
+              <ExternalLink className="size-3" />
+            </Link>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            取消
+          </Button>
+          <Button
+            className="gap-1.5"
+            disabled={!catalogUrl.trim() || importCatalog.isPending}
+            onClick={() => importCatalog.mutate()}
+          >
+            <Download className="size-3.5" />
+            {importCatalog.isPending ? '正在导入…' : '导入并进入审核'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/plugins/template-catalog.tsx
+++ b/frontend/components/plugins/template-catalog.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import Link from 'next/link'
+import { Blocks, Database, Search, Send, Sparkles, Workflow } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { useBootstrapWorkspaceProject, useMyWorkspaces } from '@/lib/api/hooks'
+import {
+  STUDIO_TEMPLATES,
+  studioAppTypeForTemplate,
+  studioGraphForTemplate,
+  studioSlug,
+  type StudioTemplateId,
+} from '@/lib/workflow/studio-templates'
+
+const CATEGORIES = ['全部', '采集与监控', '内容处理', 'Agent 分析', '分发与集成', '完整链路'] as const
+const ICONS = {
+  '采集与监控': Database,
+  '内容处理': Blocks,
+  'Agent 分析': Sparkles,
+  '分发与集成': Send,
+  '完整链路': Workflow,
+} as const
+
+/**
+ * Template catalog grid + create-from-template flow.
+ *
+ * Extracted from studio/templates/page.tsx as the Plugin Hub's canonical
+ * 模板 tab. studio/templates/page.tsx is intentionally left untouched (still
+ * its own standalone entry point reachable from Studio) — this is a parallel
+ * call site, not a shared import, so the two carry duplicated logic by design
+ * for this skeleton PR. A follow-up can fold studio/templates/page.tsx down
+ * to reuse this component once the Plugin Hub is the confirmed canonical home.
+ */
+export function TemplateCatalog() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const workspaces = useMyWorkspaces()
+  const bootstrapProject = useBootstrapWorkspaceProject()
+  const [workspaceId, setWorkspaceId] = useState<string | null>(searchParams.get('workspace'))
+  const [category, setCategory] = useState<(typeof CATEGORIES)[number]>('全部')
+  const [query, setQuery] = useState('')
+  const [selected, setSelected] = useState<StudioTemplateId | null>(null)
+  const [name, setName] = useState('')
+
+  useEffect(() => {
+    if (!workspaces.data?.length) return
+    if (!workspaceId || !workspaces.data.some((workspace) => workspace.id === workspaceId)) {
+      setWorkspaceId(workspaces.data[0].id)
+    }
+  }, [workspaceId, workspaces.data])
+
+  const visible = useMemo(
+    () =>
+      STUDIO_TEMPLATES.filter((template) => {
+        const matchesCategory = category === '全部' || template.category === category
+        const text = `${template.title} ${template.description} ${template.steps.join(' ')}`.toLowerCase()
+        return matchesCategory && text.includes(query.trim().toLowerCase())
+      }),
+    [category, query],
+  )
+  const selectedTemplate = STUDIO_TEMPLATES.find((template) => template.id === selected) ?? null
+
+  function selectTemplate(templateId: StudioTemplateId, templateName: string) {
+    setSelected(templateId)
+    setName(templateName)
+  }
+
+  function returnToTemplates() {
+    setSelected(null)
+  }
+
+  async function createFromTemplate() {
+    if (!workspaceId) {
+      toast.error('请先选择工作区，再用模板创建项目')
+      return
+    }
+    if (!selected || !name.trim() || bootstrapProject.isPending) return
+    try {
+      const result = await bootstrapProject.mutateAsync({
+        workspaceId,
+        data: {
+          project: {
+            name: name.trim(),
+            slug: `${studioSlug(name)}-${Date.now().toString(36)}`,
+            description: '由应用模板创建',
+            app_type: studioAppTypeForTemplate(selected),
+          },
+          workflow: {
+            name: name.trim(),
+            description: '模板工作流',
+            graph: studioGraphForTemplate(selected, name.trim()),
+          },
+        },
+      })
+      toast.success('模板已创建，可以继续编排')
+      router.push(
+        `/studio/workflow?workspace=${workspaceId}&project=${result.project.id}&workflow=${result.primary_workflow.id}`,
+      )
+    } catch (reason) {
+      toast.error(reason instanceof Error ? reason.message : '创建失败')
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative min-w-0 flex-1 md:max-w-xl">
+          <Search aria-hidden="true" className="pointer-events-none absolute left-3 top-3.5 size-4 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            aria-label="搜索模板"
+            className="min-h-11 rounded-xs bg-muted/35 pl-9"
+            placeholder="搜索模板、节点或用途…"
+          />
+        </div>
+        <span className="shrink-0 font-mono text-3xs text-muted-foreground" aria-live="polite">
+          {visible.length} 个模板
+        </span>
+      </div>
+
+      <nav aria-label="模板分类" className="w-full min-w-0 max-w-full overflow-hidden">
+        <div className="w-full max-w-full overflow-x-auto overscroll-x-contain pb-1">
+          <div className="flex w-max min-w-full gap-1">
+            {CATEGORIES.map((item) => {
+              const active = category === item
+              return (
+                <Button
+                  key={item}
+                  size="sm"
+                  variant={active ? 'secondary' : 'ghost'}
+                  aria-pressed={active}
+                  aria-current={active ? 'true' : undefined}
+                  className="min-h-11 shrink-0 px-3"
+                  onClick={() => setCategory(item)}
+                >
+                  {item}
+                </Button>
+              )
+            })}
+          </div>
+        </div>
+      </nav>
+
+      {visible.length ? (
+        <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-3">
+          {visible.map((template) => {
+            const Icon = ICONS[template.category]
+            return (
+              <button
+                key={template.id}
+                type="button"
+                aria-haspopup="dialog"
+                onClick={() => selectTemplate(template.id, template.title)}
+                className="group flex min-h-48 flex-col rounded-md border bg-background/60 p-4 text-left transition-[border-color,background-color,transform] hover:-translate-y-0.5 hover:border-foreground/25 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              >
+                <div className="flex items-start gap-3">
+                  <div className="grid size-10 shrink-0 place-items-center rounded-md border bg-muted/40">
+                    <Icon aria-hidden="true" className="size-4.5" />
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="truncate text-sm font-semibold">{template.title}</h3>
+                    <Badge variant="outline" className="mt-1 h-5 px-1.5 text-3xs">
+                      {template.category}
+                    </Badge>
+                  </div>
+                </div>
+                <p className="mt-3 line-clamp-2 text-xs leading-5 text-muted-foreground">{template.description}</p>
+                <div className="mt-4 flex items-center gap-1.5 overflow-hidden">
+                  {template.steps.map((step, index) => (
+                    <div key={step} className="contents">
+                      <span className="truncate rounded-sm border bg-muted/25 px-2 py-1 font-mono text-3xs text-muted-foreground">
+                        {step}
+                      </span>
+                      {index < template.steps.length - 1 ? (
+                        <span className="text-3xs text-muted-foreground/50">→</span>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+                <span className="mt-auto border-t pt-3 text-xs font-medium text-foreground">
+                  使用此模板 <span aria-hidden="true">→</span>
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      ) : (
+        <div className="grid min-h-80 place-items-center rounded-md border border-dashed text-sm text-muted-foreground">
+          没有匹配的模板，换一个关键词试试。
+        </div>
+      )}
+
+      <Dialog
+        open={selectedTemplate !== null}
+        onOpenChange={(open) => {
+          if (!open && !bootstrapProject.isPending) returnToTemplates()
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          {selectedTemplate ? (
+            <form
+              className="grid gap-4"
+              onSubmit={(event) => {
+                event.preventDefault()
+                void createFromTemplate()
+              }}
+            >
+              <DialogHeader>
+                <DialogTitle>用“{selectedTemplate.title}”创建项目</DialogTitle>
+                <DialogDescription>
+                  确认项目名称后会创建项目和第一份工作流草稿，并直接打开画布继续编排。
+                </DialogDescription>
+              </DialogHeader>
+              <label className="space-y-2 text-sm">
+                <span>项目名称</span>
+                <Input
+                  name="project-name"
+                  autoComplete="off"
+                  className="min-h-11"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                />
+              </label>
+              {!workspaceId && !workspaces.isLoading ? (
+                <p role="status" className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+                  当前没有可用工作区。返回项目页选择或创建工作区后，即可继续使用这个模板。
+                </p>
+              ) : null}
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="min-h-11"
+                  onClick={returnToTemplates}
+                  disabled={bootstrapProject.isPending}
+                >
+                  返回模板库
+                </Button>
+                {workspaceId ? (
+                  <Button type="submit" className="min-h-11" disabled={!name.trim() || bootstrapProject.isPending}>
+                    {bootstrapProject.isPending ? '正在创建…' : '创建并打开工作流'}
+                  </Button>
+                ) : workspaces.isLoading ? (
+                  <Button type="button" className="min-h-11" disabled>
+                    正在读取工作区…
+                  </Button>
+                ) : (
+                  <Button className="min-h-11" nativeButton={false} render={<Link href="/studio" />}>
+                    返回项目并选择工作区
+                  </Button>
+                )}
+              </DialogFooter>
+            </form>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/lib/navigation.ts
+++ b/frontend/lib/navigation.ts
@@ -1,5 +1,6 @@
 import {
   Activity,
+  Blocks,
   Database,
   LayoutDashboard,
   PanelsTopLeft,
@@ -42,6 +43,7 @@ export const NAV_GROUPS: NavGroup[] = [
     label: '构建',
     items: [
       { href: '/studio', label: '项目', icon: PanelsTopLeft, match: ['/studio', '/canvas'] },
+      { href: '/plugins', label: '插件中心', icon: Blocks },
       {
         href: '/sources',
         label: '自动化与 Agent',
@@ -82,6 +84,7 @@ export const ROUTE_LABELS: Record<string, string> = {
   '/studio': '项目',
   '/studio/workflow': '工作流编排',
   '/canvas': '节点工作流（兼容入口）',
+  '/plugins': '插件中心',
   '/sources': '自动化与 Agent',
   '/schedules': '触发与调度',
   '/tasks': '工作项',


### PR DESCRIPTION
Epic #25 落地骨架。方向纠偏后 (RSS 源库/模板不各拆, 统一收进 Dify 式 Plugin 中心) 的第一步。基于 codex/rss-provider-ecosystem 分支。

## What

- 新建 `/plugins` 统一插件中心, 子类型 tab: 源库 / 模板 / 工具 / Agent / 触发器 / 扩展 (参照 Dify Marketplace 类型划分)
- **源库 tab**: RSS 导入能力从 sources 页迁入, 抽成 `components/plugins/rss-catalog-import-dialog.tsx`
- **模板 tab**: 抽 `components/plugins/template-catalog.tsx` 作为中心内规范入口
- 其余四类占位 EmptyState「即将上线」
- **sources 页移除「导入 RSS 源库」按钮** — 源库是目录动作归中心, sources 页只管数据源实例 (表格/分页逻辑原样保留, RSS 残留清零)
- 侧栏加「插件中心」入口 (`/plugins`, Blocks 图标)

## 设计决策 (Fable 审计已核)

- RouteTabs 是 `usePathname()` 驱动, 不适用单页多子类型 → 手搓 pill-tab 视觉对齐 RouteTabs (同类名/同 layoutId 滑块动画/Ripple), 状态走 `?type=` 参数 (可分享/可链接)。未动 route-tabs.tsx
- ADR 0014/0015 的 "plugin" 指后端能力 manifest (权限/健康探针), 与本前端内容目录 (源库/模板) 是不同概念, 无冲突; 命名 reviewer 后续可消歧

## Test

- `tsc --noEmit` exit 0 零错误; `lint` exit 0 零新警告 (9 个存量警告在未触碰文件)
- Fable 抽查: 数据源表格 9 处关键引用完整、RSS 残留 0、侧栏入口就位、PageContainer 支持 tabs prop

## 骨架边界 (后续跟进)

- 工具/Agent/触发器/扩展 tab 仅占位, 未接数据
- `studio/templates/page.tsx` 原样保留 (out of scope), 与 TemplateCatalog 暂重复; 后续可折叠为共享组件
- **可发现性缺口**: 旧 RSS 导入成功后会把 sources 页筛到 disabled 让用户看到新源; 迁入中心后该页内状态断了。导入后仅 toast 计数, 无直达新建 (disabled) 源的路径。建议 follow-up: toast action 链到 /sources
