### PR TITLE
feat(workflow): materialize certified tool capabilities as nodes

### DIFF
--- a/backend/workflow/capability_projection.py
+++ b/backend/workflow/capability_projection.py
@@ -60,6 +60,7 @@ def build_workflow_capabilities(
             *_catalog_capabilities(
                 dify_runtime_ready=_dify_runtime_ready(plugin_installations or [])
             ),
+            *_tool_catalog_capabilities(),
             *_plugin_catalog_capabilities(plugin_installations or []),
         ],
         primitives=_primitive_capabilities(),
@@ -1362,6 +1363,119 @@ def _resource_capabilities() -> list[WorkflowRuntimeCapability]:
         )
         for tool in list_workflow_tool_capabilities().tools
     )
+    return rows
+
+
+def _tool_catalog_capabilities() -> list[WorkflowRuntimeCapability]:
+    rows: list[WorkflowRuntimeCapability] = []
+    for tool in list_workflow_tool_capabilities().tools:
+        canvas = tool.manifest.get("canvas")
+        node_catalog = tool.manifest.get("nodeCatalog")
+        if (
+            not isinstance(canvas, dict)
+            or canvas.get("node") is not True
+            or not isinstance(node_catalog, dict)
+            or node_catalog.get("authority") != "backend"
+        ):
+            continue
+
+        catalog_id = node_catalog.get("id")
+        kind = node_catalog.get("kind")
+        capability = node_catalog.get("capability")
+        if (
+            not isinstance(catalog_id, str)
+            or kind
+            not in {
+                "schedule",
+                "source",
+                "agent",
+                "router",
+                "notify",
+                "inbox",
+                "action",
+                "flow",
+                "control",
+                "sink",
+            }
+            or capability
+            not in {
+                "trigger",
+                "fetch",
+                "normalize",
+                "dedupe",
+                "summarize",
+                "score",
+                "tag",
+                "route",
+                "send",
+                "store",
+                "merge",
+                "accept",
+            }
+        ):
+            continue
+
+        presentation = tool.manifest.get("presentation")
+        presentation = dict(presentation) if isinstance(presentation, dict) else {}
+        parameters = presentation.get("parameters")
+        parameters = list(parameters) if isinstance(parameters, list) else []
+        tool_capability = {
+            "id": tool.id,
+            "versionPin": tool.versionPin.model_dump() if tool.versionPin else None,
+            "inputPorts": [port.model_dump() for port in tool.inputPorts],
+            "outputPorts": [port.model_dump() for port in tool.outputPorts],
+            "executor": tool.executor.model_dump(),
+        }
+        manifest = {
+            **tool.manifest,
+            "toolCapability": tool_capability,
+            "presentation": {
+                **presentation,
+                "parameters": [
+                    {
+                        "name": "toolCapability",
+                        "label": "系统工具绑定 / Tool binding",
+                        "type": "object",
+                        "required": True,
+                        "default": {
+                            "id": tool.id,
+                            "versionPin": tool_capability["versionPin"],
+                            "executor": tool_capability["executor"],
+                        },
+                    },
+                    {
+                        "name": "toolParams",
+                        "label": "运行参数 / Runtime parameters",
+                        "type": "object",
+                        "required": False,
+                        "default": dict(tool.executor.params),
+                    },
+                    *parameters,
+                ],
+            },
+        }
+        rows.append(
+            _capability(
+                id=catalog_id,
+                label=tool.label,
+                surface="catalog",
+                status=tool.status,
+                backend_available=tool.status == "runnable",
+                kind=kind,
+                capability=capability,
+                provider=tool.provider,
+                runtime_binding=_read_manifest_runtime_binding(tool.manifest),
+                reason=tool.description,
+                missing=(
+                    []
+                    if tool.status == "runnable"
+                    else ["tool_capability_unavailable"]
+                ),
+                tags=["catalog", "tool-capability", *tool.tags],
+                source="backend.workflow.tool_capabilities",
+                manifest=manifest,
+            )
+        )
     return rows
 
 

--- a/backend/workflow/compiler.py
+++ b/backend/workflow/compiler.py
@@ -388,14 +388,14 @@ def _validate_project(project: WorkflowProject) -> list[WorkflowCompileError]:
 def _validate_capability_version_pin(
     node: WorkflowProjectNode,
 ) -> list[WorkflowCompileError]:
-    if _read_string((node.ui or {}).get("catalogId")) != "external.tool.capability":
-        return []
-
     tool_capability = node.params.get("toolCapability")
     if not isinstance(tool_capability, dict):
         return []
     tool_id = _read_string(tool_capability.get("id"))
     if tool_id is None:
+        return []
+    catalog_id = _read_string((node.ui or {}).get("catalogId"))
+    if catalog_id not in {"external.tool.capability", tool_id}:
         return []
 
     issue = validate_workflow_tool_capability_version_pin(

--- a/backend/workflow/node_registry.py
+++ b/backend/workflow/node_registry.py
@@ -231,6 +231,8 @@ def resolve_node_origin(node: WorkflowProjectNode) -> WorkflowNodeOrigin:
 
     if catalog_id in WORKFLOW_CATALOG_IDS:
         return WorkflowNodeOrigin(kind="node_library", catalog_id=catalog_id)
+    if _is_registered_tool_capability_node(node, catalog_id):
+        return WorkflowNodeOrigin(kind="node_library", catalog_id=catalog_id)
     if primitive_id in WORKFLOW_PRIMITIVE_IDS:
         return WorkflowNodeOrigin(kind="primitive_library", primitive_id=primitive_id)
     if n8n is not None:
@@ -248,6 +250,23 @@ def resolve_node_origin(node: WorkflowProjectNode) -> WorkflowNodeOrigin:
     if missing_capability:
         notes.append(f"missing capability: {missing_capability}")
     return WorkflowNodeOrigin(kind="legacy", missing_capability=missing_capability, notes=notes)
+
+
+def _is_registered_tool_capability_node(
+    node: WorkflowProjectNode,
+    catalog_id: str | None,
+) -> bool:
+    tool = node.params.get("toolCapability")
+    if not isinstance(tool, dict):
+        return False
+    tool_id = _read_string(tool.get("id"))
+    if tool_id is None or catalog_id != tool_id:
+        return False
+
+    # Local import avoids making the registry depend on this origin guard at import time.
+    from backend.workflow.tool_capabilities import resolve_workflow_tool_capability
+
+    return resolve_workflow_tool_capability(tool_id) is not None
 
 
 def forbidden_node_definition_keys(node: WorkflowProjectNode) -> list[str]:

--- a/backend/workflow/runtime_registry.py
+++ b/backend/workflow/runtime_registry.py
@@ -1134,7 +1134,12 @@ def _is_inbox_store_node(node: WorkflowProjectNode) -> bool:
 
 
 def _is_external_tool_capability(node: WorkflowProjectNode) -> bool:
-    return _read_string((node.ui or {}).get("catalogId")) == "external.tool.capability"
+    catalog_id = _read_string((node.ui or {}).get("catalogId"))
+    if catalog_id == "external.tool.capability":
+        return True
+    tool_capability = _read_dict(node.params.get("toolCapability"))
+    tool_id = _read_string(tool_capability.get("id"))
+    return tool_id is not None and catalog_id == tool_id
 
 
 def _is_schedule_trigger(node: WorkflowProjectNode) -> bool:

--- a/backend/workflow/tool_capabilities.py
+++ b/backend/workflow/tool_capabilities.py
@@ -304,6 +304,11 @@ def _tool_capabilities() -> list[WorkflowToolCapability]:
                     "topK": 10,
                 },
             ),
+            catalog={
+                "id": SITUATION_AWARENESS_TOOL_CAPABILITY_ID,
+                "category": "processing",
+                "icon": "Radar",
+            },
         ),
         _realtime_tool(
             id=SWARM_SIMULATION_TOOL_CAPABILITY_ID,
@@ -335,6 +340,11 @@ def _tool_capabilities() -> list[WorkflowToolCapability]:
                     "enableGraphMemoryUpdate": False,
                 },
             ),
+            catalog={
+                "id": SWARM_SIMULATION_TOOL_CAPABILITY_ID,
+                "category": "processing",
+                "icon": "Network",
+            },
         ),
         *[_native_intelligence_tool(action) for action in NATIVE_INTELLIGENCE_ACTIONS],
     ]
@@ -375,6 +385,7 @@ def _realtime_tool(
     schema: str,
     resources: list[str],
     executor: WorkflowToolCapabilityExecutor | None = None,
+    catalog: dict[str, str] | None = None,
 ) -> WorkflowToolCapability:
     return WorkflowToolCapability(
         id=id,
@@ -404,6 +415,21 @@ def _realtime_tool(
                     "completed",
                 ]
             },
-            "canvas": {"node": False},
+            "canvas": {"node": catalog is not None},
+            **(
+                {
+                    "nodeCatalog": {
+                        "id": catalog["id"],
+                        "authority": "backend",
+                        "origin": "tool-capability",
+                        "category": catalog["category"],
+                        "kind": "action",
+                        "capability": "store",
+                    },
+                    "presentation": {"icon": catalog["icon"]},
+                }
+                if catalog is not None
+                else {}
+            ),
         },
     )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "check:navigation-transitions": "node --test scripts/check-navigation-transition-regressions.mjs",
     "check:control-plane": "node --test scripts/check-control-plane-regressions.mjs scripts/check-dashboard-regressions.mjs scripts/check-inbox-regressions.mjs scripts/check-visualization-regressions.mjs",
     "check:dify-p0": "node --test scripts/check-dify-p0-regressions.mjs",
-    "check:node-capabilities": "node --test scripts/check-node-capability-catalog-regressions.mjs",
+    "check:node-capabilities": "node --test scripts/check-node-capability-catalog-regressions.mjs scripts/check-tool-capability-catalog-regressions.mjs",
     "check:record-hygiene": "node --test scripts/check-record-hygiene-regressions.mjs",
     "check:record-relationships": "node --test scripts/check-record-relationship-regressions.mjs",
     "check:opencli-business-workflows": "node --test scripts/check-opencli-business-workflows.mjs",

--- a/frontend/scripts/check-tool-capability-catalog-regressions.mjs
+++ b/frontend/scripts/check-tool-capability-catalog-regressions.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict"
+import { existsSync, readFileSync } from "node:fs"
+import { registerHooks, stripTypeScriptTypes } from "node:module"
+import { test } from "node:test"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import path from "node:path"
+
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const candidates = []
+    if (specifier.startsWith("@/")) {
+      candidates.push(path.join(frontendRoot, specifier.slice(2)))
+    } else if (specifier.startsWith(".") && context.parentURL?.startsWith("file:")) {
+      candidates.push(path.resolve(path.dirname(fileURLToPath(context.parentURL)), specifier))
+    }
+    for (const candidate of candidates) {
+      for (const resolvedPath of [candidate, `${candidate}.ts`, `${candidate}.tsx`]) {
+        if (existsSync(resolvedPath)) {
+          return { url: pathToFileURL(resolvedPath).href, shortCircuit: true }
+        }
+      }
+    }
+    return nextResolve(specifier, context)
+  },
+  load(url, context, nextLoad) {
+    if (url.endsWith(".ts") || url.endsWith(".tsx")) {
+      const source = stripTypeScriptTypes(readFileSync(fileURLToPath(url), "utf8"), {
+        mode: "strip",
+        sourceUrl: url,
+      })
+      return { format: "module", source, shortCircuit: true }
+    }
+    return nextLoad(url, context)
+  },
+})
+
+test("backend tool capability becomes an executable catalog node", async () => {
+  const { createWorkflowNodeFromCatalog, getWorkflowNodeCatalog } = await import(
+    pathToFileURL(path.join(frontendRoot, "lib/workflow/node-catalog.ts")).href
+  )
+  const toolCapability = {
+    id: "tool.osint.metasearch",
+    versionPin: {
+      package: "opencli-admin",
+      packageVersion: "0.1.0",
+      capabilityVersion: "1.0.0",
+      provenance: "built-in",
+    },
+    executor: { mode: "fixture", params: { limit: 20 } },
+  }
+  const runtimeCapability = {
+    id: "tool.osint.metasearch",
+    label: "OSINT Metasearch",
+    surface: "catalog",
+    status: "runnable",
+    backendAvailable: true,
+    kind: "action",
+    capability: "store",
+    provider: "opencli-admin",
+    runtimeBinding: "workflow.external-tool.capability",
+    reason: "Search verified OSINT providers.",
+    missing: [],
+    tags: ["catalog", "tool-capability", "osint"],
+    source: "backend.workflow.tool_capabilities",
+    manifest: {
+      canvas: { node: true },
+      nodeCatalog: {
+        authority: "backend",
+        origin: "tool-capability",
+        category: "processing",
+      },
+      presentation: {
+        icon: "Search",
+        parameters: [
+          {
+            name: "toolCapability",
+            label: "Tool binding",
+            type: "object",
+            required: true,
+            default: toolCapability,
+          },
+          {
+            name: "toolParams",
+            label: "Runtime parameters",
+            type: "object",
+            default: { limit: 20 },
+          },
+        ],
+      },
+    },
+  }
+  const capabilities = {
+    version: "test",
+    catalog: [runtimeCapability],
+    primitives: [],
+    channels: [],
+    notifiers: [],
+    triggers: [],
+    resources: [],
+  }
+
+  const item = getWorkflowNodeCatalog("intelligence", capabilities).find(
+    (candidate) => candidate.id === runtimeCapability.id,
+  )
+  assert.ok(item)
+  assert.equal(item.kind, "action")
+  assert.equal(item.capability, "store")
+  assert.deepEqual(item.params.toolCapability, toolCapability)
+  assert.deepEqual(item.params.toolParams, { limit: 20 })
+
+  const node = createWorkflowNodeFromCatalog(item, "osint-search", { x: 80, y: 120 })
+  assert.deepEqual(node.params.toolCapability, toolCapability)
+  assert.deepEqual(node.params.toolParams, { limit: 20 })
+  assert.equal(node.ui.catalogId, "tool.osint.metasearch")
+})

--- a/tests/unit/test_workflow_tool_catalog_projection.py
+++ b/tests/unit/test_workflow_tool_catalog_projection.py
@@ -58,3 +58,79 @@ def test_tool_capability_catalog_projection_is_explicit_and_executable(monkeypat
     }
     assert "resource.tool-capability.tool.osint.metasearch" in resources
     assert "resource.tool-capability.tool.osint.hidden" in resources
+
+
+from copy import deepcopy
+
+from backend.schemas.workflow import WorkflowProject, WorkflowProjectNode
+from backend.workflow.compiler import compile_workflow_project
+from backend.workflow.runtime_registry import (
+    EXTERNAL_TOOL_BINDING_ID,
+    resolve_runtime_metadata,
+)
+
+
+TOOL_ID = "tool.intelligence.situation-awareness"
+
+
+def _projected_tool_node() -> WorkflowProjectNode:
+    capability = next(
+        item for item in build_workflow_capabilities().catalog if item.id == TOOL_ID
+    )
+    parameters = capability.manifest["presentation"]["parameters"]
+    params = {
+        parameter["name"]: deepcopy(parameter["default"])
+        for parameter in parameters
+        if "default" in parameter
+    }
+    return WorkflowProjectNode.model_validate(
+        {
+            "id": "projected-tool",
+            "kind": capability.kind,
+            "capability": capability.capability,
+            "params": params,
+            "ui": {"catalogId": capability.id},
+        }
+    )
+
+
+def _project(node: WorkflowProjectNode) -> WorkflowProject:
+    return WorkflowProject.model_validate(
+        {
+            "id": "tool-catalog-round-trip",
+            "name": "Tool catalog round trip",
+            "profile": "intelligence",
+            "nodes": [node.model_dump(mode="json")],
+            "edges": [],
+            "adapters": [],
+        }
+    )
+
+
+def test_projected_tool_node_compiles_and_resolves_runtime_with_correct_pin():
+    node = _projected_tool_node()
+
+    compiled = compile_workflow_project(_project(node))
+    assert compiled.valid is True
+    assert compiled.errors == []
+
+    metadata = resolve_runtime_metadata(node, None)
+    assert metadata.get("missing_runtime") is None
+    assert metadata["binding"]["binding_id"] == EXTERNAL_TOOL_BINDING_ID
+    assert metadata["binding"]["input"]["toolCapabilityId"] == TOOL_ID
+    assert (
+        metadata["binding"]["input"]["toolCapabilityVersionPin"]
+        == node.params["toolCapability"]["versionPin"]
+    )
+
+
+def test_projected_tool_node_rejects_stale_version_pin():
+    node = _projected_tool_node()
+    node.params["toolCapability"]["versionPin"]["capabilityVersion"] = "999.0.0"
+
+    compiled = compile_workflow_project(_project(node))
+
+    assert compiled.valid is False
+    assert "tool_capability_version_pin_mismatch" in {
+        error.code for error in compiled.errors
+    }

--- a/tests/unit/test_workflow_tool_catalog_projection.py
+++ b/tests/unit/test_workflow_tool_catalog_projection.py
@@ -1,0 +1,60 @@
+from backend.workflow.capability_projection import build_workflow_capabilities
+from backend.workflow.tool_capabilities import list_workflow_tool_capabilities
+
+
+def test_tool_capability_catalog_projection_is_explicit_and_executable(monkeypatch):
+    registry = list_workflow_tool_capabilities()
+    fixture = next(tool for tool in registry.tools if tool.id == "tool.search.fixture")
+    projected = fixture.model_copy(
+        update={
+            "id": "tool.osint.metasearch",
+            "label": "OSINT Metasearch",
+            "manifest": {
+                **fixture.manifest,
+                "canvas": {"node": True},
+                "nodeCatalog": {
+                    "id": "tool.osint.metasearch",
+                    "authority": "backend",
+                    "origin": "tool-capability",
+                    "category": "processing",
+                    "kind": "action",
+                    "capability": "store",
+                },
+                "presentation": {"icon": "Search"},
+            },
+        },
+        deep=True,
+    )
+    hidden = fixture.model_copy(update={"id": "tool.osint.hidden"}, deep=True)
+    response = registry.model_copy(update={"tools": [projected, hidden]})
+    monkeypatch.setattr(
+        "backend.workflow.capability_projection.list_workflow_tool_capabilities",
+        lambda: response,
+    )
+
+    capabilities = build_workflow_capabilities()
+    catalog = {item.id: item for item in capabilities.catalog}
+    resources = {item.id: item for item in capabilities.resources}
+
+    assert "tool.osint.metasearch" in catalog
+    assert "tool.osint.hidden" not in catalog
+    item = catalog["tool.osint.metasearch"]
+    assert item.status == "runnable"
+    assert item.backendAvailable is True
+    assert item.kind == "action"
+    assert item.capability == "store"
+    assert item.runtimeBinding == "workflow.external-tool.capability"
+    assert item.manifest["toolCapability"]["id"] == "tool.osint.metasearch"
+    assert item.manifest["toolCapability"]["executor"]["mode"] == "fixture"
+    assert [field["name"] for field in item.manifest["presentation"]["parameters"][:2]] == [
+        "toolCapability",
+        "toolParams",
+    ]
+    assert item.manifest["presentation"]["parameters"][0]["default"]["versionPin"] == {
+        "package": "opencli-admin",
+        "packageVersion": "0.1.0",
+        "capabilityVersion": "1.0.0",
+        "provenance": "built-in",
+    }
+    assert "resource.tool-capability.tool.osint.metasearch" in resources
+    assert "resource.tool-capability.tool.osint.hidden" in resources


### PR DESCRIPTION
## Outcome

Turn explicitly opted-in, machine-runnable Tool Capabilities into backend-authoritative Canvas catalog nodes instead of leaving them only in the resource list.

## Changes

- add a generic Tool Capability → catalog projection bridge gated by `nodeCatalog.authority=backend` and `canvas.node=true`
- preserve runtime binding, version pin, executor, typed ports, readiness, and resource projection
- expose the existing deterministic situation-awareness and swarm-simulation capabilities as direct tool nodes
- accept dynamic catalog IDs only when `ui.catalogId == params.toolCapability.id` and that ID exists in the backend registry
- add backend and frontend regression coverage for catalog → node → compile → runtime binding → stale pin rejection

## Safety

- capabilities remain hidden unless they explicitly opt in
- blocked capabilities remain blocked
- unknown or forged Tool Capability IDs remain rejected
- fake/fixture-only realtime tools remain resource-only
- no new dependency or runtime executor

## Verification

- `pytest -q --no-cov tests/unit/test_workflow_tool_catalog_projection.py tests/integration/test_workflow_intelligence_tools.py` → 7 passed
- `pnpm --dir frontend run check:node-capabilities` → 12 passed
- targeted `py_compile` → passed
- `git diff --check 1d8b0e8..HEAD` → passed
- correct pin compiles and binds `workflow.external-tool.capability`
- stale pin fails only with `tool_capability_version_pin_mismatch`

Independent verifier verdict: PASS.