### PR TITLE
feat(workflow): productize SearXNG and RSSHub source nodes

### DIFF
--- a/backend/workflow/capability_projection.py
+++ b/backend/workflow/capability_projection.py
@@ -337,7 +337,6 @@ def _catalog_capabilities(*, dify_runtime_ready: bool) -> list[WorkflowRuntimeCa
                             "channelType": "rest",
                             "method": "GET",
                             "query": {"format": "json"},
-                            "resultPath": "results",
                         },
                     },
                 },

--- a/backend/workflow/capability_projection.py
+++ b/backend/workflow/capability_projection.py
@@ -295,6 +295,169 @@ def _catalog_capabilities(*, dify_runtime_ready: bool) -> list[WorkflowRuntimeCa
             ),
         ),
         _capability(
+            id="intelligence.source.searxng",
+            label="SearXNG 元搜索 / Metasearch",
+            surface="catalog",
+            status="runnable",
+            backend_available=True,
+            kind="source",
+            capability="fetch",
+            provider="http",
+            channel_type="rest",
+            runtime_binding=SOURCE_FETCH_BINDING_ID,
+            reason=(
+                "Runs a configured SearXNG JSON Search API through the guarded "
+                "HTTP source executor and emits results as workflow items."
+            ),
+            tags=["source", "osint", "searxng", "metasearch", "live"],
+            source="backend.workflow.http_source_executor",
+            manifest={
+                **_manifest(
+                    schema="capability.source.searxng.v1",
+                    input_ports=[_port("in", "trigger")],
+                    output_ports=[_port("out", "items[]")],
+                    resources=["searxng_service", "allowed_domains"],
+                    permissions=["canFetchNetwork"],
+                    runtime_binding=SOURCE_FETCH_BINDING_ID,
+                    probes=["searxng_json_enabled", "source_domain_allowed"],
+                ),
+                "canvas": {"node": True},
+                "nodeCatalog": {
+                    "authority": "backend",
+                    "origin": "source-preset",
+                    "category": "source",
+                    "kind": "source",
+                    "capability": "fetch",
+                    "adapter": {
+                        "id": "source-searxng-http",
+                        "type": "source",
+                        "provider": "http",
+                        "mode": "live",
+                        "config": {
+                            "channelType": "rest",
+                            "method": "GET",
+                            "query": {"format": "json"},
+                            "resultPath": "results",
+                        },
+                    },
+                },
+                "presentation": {
+                    "icon": "Search",
+                    "description": (
+                        "连接自托管 SearXNG JSON API；查询参数随节点保存，"
+                        "域名仍受工作流网络权限约束。"
+                    ),
+                    "parameters": [
+                        {
+                            "name": "endpoint",
+                            "label": "搜索地址 / Search endpoint",
+                            "type": "string",
+                            "required": True,
+                        },
+                        {
+                            "name": "query",
+                            "label": "查询参数 / Query parameters",
+                            "type": "object",
+                            "required": True,
+                            "default": {
+                                "q": "OpenCLI",
+                                "format": "json",
+                                "categories": "general",
+                            },
+                        },
+                        {
+                            "name": "resultPath",
+                            "label": "结果路径 / Result path",
+                            "type": "string",
+                            "required": True,
+                            "default": "results",
+                        },
+                        {
+                            "name": "sourceGroup",
+                            "label": "来源分组 / Source group",
+                            "type": "string",
+                            "default": "web-search",
+                        },
+                    ],
+                },
+            },
+        ),
+        _capability(
+            id="intelligence.source.rsshub",
+            label="RSSHub 路由 / Route",
+            surface="catalog",
+            status="runnable",
+            backend_available=True,
+            kind="source",
+            capability="fetch",
+            provider="rss",
+            channel_type="rss",
+            runtime_binding=SOURCE_FETCH_BINDING_ID,
+            reason=(
+                "Runs an RSSHub route through the existing RSS/Atom executor "
+                "with source grouping, retry, lineage, and Provider support."
+            ),
+            tags=["source", "osint", "rsshub", "rss", "live"],
+            source="backend.workflow.rss_source_executor",
+            manifest={
+                **_manifest(
+                    schema="capability.source.rsshub.v1",
+                    input_ports=[_port("in", "trigger")],
+                    output_ports=[_port("out", "items[]")],
+                    resources=[
+                        "rss_channel",
+                        "feed_provider_registry",
+                        "allowed_domains",
+                    ],
+                    permissions=["canFetchNetwork"],
+                    runtime_binding=SOURCE_FETCH_BINDING_ID,
+                    probes=["rsshub_route_available", "source_domain_allowed"],
+                ),
+                "canvas": {"node": True},
+                "nodeCatalog": {
+                    "authority": "backend",
+                    "origin": "source-preset",
+                    "category": "source",
+                    "kind": "source",
+                    "capability": "fetch",
+                    "adapter": {
+                        "id": "source-rsshub-feed",
+                        "type": "source",
+                        "provider": "rss",
+                        "mode": "live",
+                        "config": {"channel": "rss"},
+                    },
+                },
+                "presentation": {
+                    "icon": "Rss",
+                    "description": (
+                        "读取自托管 RSSHub 路由或已登记的 Feed Provider，"
+                        "保留来源分组与运行血缘。"
+                    ),
+                    "parameters": [
+                        {
+                            "name": "feedUrl",
+                            "label": "订阅地址 / Feed URL",
+                            "type": "string",
+                            "required": True,
+                        },
+                        {
+                            "name": "maxEntries",
+                            "label": "最大条目 / Max entries",
+                            "type": "integer",
+                            "default": 20,
+                        },
+                        {
+                            "name": "sourceGroup",
+                            "label": "来源分组 / Source group",
+                            "type": "string",
+                            "default": "rsshub",
+                        },
+                    ],
+                },
+            },
+        ),
+        _capability(
             id="intelligence.source.opencli-slot",
             label="OpenCLI Source Slot",
             surface="catalog",

--- a/backend/workflow/http_source_executor.py
+++ b/backend/workflow/http_source_executor.py
@@ -93,7 +93,10 @@ async def execute_workflow_http_source(
         )
 
     headers = _string_dict(config.get("headers"))
-    query = _read_dict(config.get("query") or config.get("params"))
+    query = {
+        **_read_dict(config.get("query") or config.get("params")),
+        **_read_dict(params.get("query") or params.get("queryParams")),
+    }
     body = config.get("body", config.get("json"))
     result_path = _first_string(
         config.get("resultPath"),

--- a/backend/workflow/node_registry.py
+++ b/backend/workflow/node_registry.py
@@ -22,6 +22,8 @@ WORKFLOW_CATALOG_IDS = {
     "intelligence.schedule.cron",
     "intelligence.source.jin10",
     "intelligence.source.rss",
+    "intelligence.source.rsshub",
+    "intelligence.source.searxng",
     "intelligence.source.pool",
     "intelligence.source.opencli-slot",
     "intelligence.processing.normalize",

--- a/frontend/lib/workflow/node-catalog.ts
+++ b/frontend/lib/workflow/node-catalog.ts
@@ -1298,8 +1298,12 @@ function backendNodeCatalogItem(
     ? backendCatalogCategory(nodeCatalog.category)
     : pluginCatalogCategory(typeof plugin?.family === "string" ? plugin.family : "tool")
   const origin = typeof nodeCatalog?.origin === "string" ? nodeCatalog.origin : "plugin"
-  const parsedAdapter = adapterBindingSchema.safeParse(nodeCatalog?.adapter)
-  const adapter = parsedAdapter.success ? parsedAdapter.data : undefined
+  const adapterValue = nodeCatalog?.adapter
+  const parsedAdapter = adapterValue === undefined
+    ? undefined
+    : adapterBindingSchema.safeParse(adapterValue)
+  if (parsedAdapter && !parsedAdapter.success) return null
+  const adapter = parsedAdapter?.data
   const description = typeof presentation?.description === "string"
     ? presentation.description
     : runtimeCapability.reason ?? "后端节点能力"

--- a/frontend/lib/workflow/node-catalog.ts
+++ b/frontend/lib/workflow/node-catalog.ts
@@ -11,7 +11,7 @@ import type {
   WorkflowProject,
   WorkflowProjectNode,
 } from "./schema"
-import { parseWorkflowProject } from "./schema"
+import { adapterBindingSchema, parseWorkflowProject } from "./schema"
 import { getNodeInternals } from "./node-internals"
 import {
   createDataOperatorParameterInterface,
@@ -1298,6 +1298,8 @@ function backendNodeCatalogItem(
     ? backendCatalogCategory(nodeCatalog.category)
     : pluginCatalogCategory(typeof plugin?.family === "string" ? plugin.family : "tool")
   const origin = typeof nodeCatalog?.origin === "string" ? nodeCatalog.origin : "plugin"
+  const parsedAdapter = adapterBindingSchema.safeParse(nodeCatalog?.adapter)
+  const adapter = parsedAdapter.success ? parsedAdapter.data : undefined
   const description = typeof presentation?.description === "string"
     ? presentation.description
     : runtimeCapability.reason ?? "后端节点能力"
@@ -1315,6 +1317,8 @@ function backendNodeCatalogItem(
     capability,
     icon,
     color: "var(--muted-foreground)",
+    adapter: adapter?.id,
+    requiredAdapters: adapter ? [adapter] : undefined,
     params: {
       ...catalogParameterDefaults(presentation?.parameters),
       pluginInstallationId: plugin?.installationId,
@@ -1359,7 +1363,7 @@ function pluginCatalogCategory(family: string): WorkflowNodeCatalogCategory {
 
 function backendCatalogCategory(value: string): WorkflowNodeCatalogCategory {
   if (value === "input" || value === "trigger") return "trigger"
-  if (value === "knowledge") return "source"
+  if (value === "source" || value === "knowledge") return "source"
   if (value === "logic") return "decision"
   if (value === "flow") return "flow"
   if (value === "human") return "control"

--- a/frontend/scripts/check-tool-capability-catalog-regressions.mjs
+++ b/frontend/scripts/check-tool-capability-catalog-regressions.mjs
@@ -134,7 +134,6 @@ test("backend source preset materializes its real adapter", async () => {
       channelType: "rest",
       method: "GET",
       query: { format: "json" },
-      resultPath: "results",
     },
   }
   const runtimeCapability = {

--- a/frontend/scripts/check-tool-capability-catalog-regressions.mjs
+++ b/frontend/scripts/check-tool-capability-catalog-regressions.mjs
@@ -115,3 +115,125 @@ test("backend tool capability becomes an executable catalog node", async () => {
   assert.deepEqual(node.params.toolParams, { limit: 20 })
   assert.equal(node.ui.catalogId, "tool.osint.metasearch")
 })
+
+
+test("backend source preset materializes its real adapter", async () => {
+  const {
+    addCatalogNodeToWorkflowProject,
+    createWorkflowNodeFromCatalog,
+    getWorkflowNodeCatalog,
+  } = await import(
+    pathToFileURL(path.join(frontendRoot, "lib/workflow/node-catalog.ts")).href
+  )
+  const sourceAdapter = {
+    id: "source-searxng-http",
+    type: "source",
+    provider: "http",
+    mode: "live",
+    config: {
+      channelType: "rest",
+      method: "GET",
+      query: { format: "json" },
+      resultPath: "results",
+    },
+  }
+  const runtimeCapability = {
+    id: "intelligence.source.searxng",
+    label: "SearXNG 元搜索 / Metasearch",
+    surface: "catalog",
+    status: "runnable",
+    backendAvailable: true,
+    kind: "source",
+    capability: "fetch",
+    provider: "http",
+    runtimeBinding: "workflow.source.fetch",
+    reason: "Runs the configured SearXNG JSON API.",
+    missing: [],
+    tags: ["source", "osint", "searxng"],
+    source: "backend.workflow.http_source_executor",
+    manifest: {
+      canvas: { node: true },
+      nodeCatalog: {
+        authority: "backend",
+        origin: "source-preset",
+        category: "source",
+        adapter: sourceAdapter,
+      },
+      presentation: {
+        icon: "Search",
+        parameters: [
+          {
+            name: "endpoint",
+            label: "搜索地址 / Search endpoint",
+            type: "string",
+            required: true,
+          },
+          {
+            name: "query",
+            label: "查询参数 / Query parameters",
+            type: "object",
+            required: true,
+            default: { q: "OpenCLI", format: "json" },
+          },
+        ],
+      },
+    },
+  }
+  const capabilities = {
+    version: "test",
+    catalog: [runtimeCapability],
+    primitives: [],
+    channels: [],
+    notifiers: [],
+    triggers: [],
+    resources: [],
+  }
+
+  const item = getWorkflowNodeCatalog("intelligence", capabilities).find(
+    (candidate) => candidate.id === runtimeCapability.id,
+  )
+  assert.ok(item)
+  assert.equal(item.category, "source")
+  assert.equal(item.adapter, sourceAdapter.id)
+  assert.deepEqual(item.requiredAdapters, [sourceAdapter])
+
+  const node = createWorkflowNodeFromCatalog(item, "searxng-source", { x: 80, y: 120 })
+  assert.equal(node.adapter, sourceAdapter.id)
+  assert.deepEqual(node.params.query, { q: "OpenCLI", format: "json" })
+
+  const project = addCatalogNodeToWorkflowProject(
+    {
+      id: "source-preset-round-trip",
+      name: "Source preset round trip",
+      profile: "intelligence",
+      version: 1,
+      nodes: [
+        {
+          id: "start",
+          kind: "schedule",
+          capability: "trigger",
+          params: {},
+          ui: { label: "Start", position: { x: 0, y: 0 } },
+        },
+      ],
+      edges: [],
+      settings: {
+        timezone: "Asia/Shanghai",
+        deterministicSimulation: true,
+        maxItemsPerRun: 20,
+      },
+      adapters: [],
+      agentPermissions: {
+        canFetchNetwork: true,
+        canSendNotifications: false,
+        canWriteInbox: true,
+        allowedDomains: [],
+      },
+    },
+    item,
+    "searxng-source",
+    { x: 80, y: 120 },
+  )
+  assert.deepEqual(project.adapters, [sourceAdapter])
+  assert.equal(project.nodes.at(-1).adapter, sourceAdapter.id)
+})

--- a/frontend/scripts/check-tool-capability-catalog-regressions.mjs
+++ b/frontend/scripts/check-tool-capability-catalog-regressions.mjs
@@ -235,4 +235,24 @@ test("backend source preset materializes its real adapter", async () => {
   )
   assert.deepEqual(project.adapters, [sourceAdapter])
   assert.equal(project.nodes.at(-1).adapter, sourceAdapter.id)
+
+  const malformedCapability = {
+    ...runtimeCapability,
+    id: "intelligence.source.malformed",
+    manifest: {
+      ...runtimeCapability.manifest,
+      nodeCatalog: {
+        ...runtimeCapability.manifest.nodeCatalog,
+        adapter: { id: "missing-required-fields" },
+      },
+    },
+  }
+  const malformedCatalog = getWorkflowNodeCatalog("intelligence", {
+    ...capabilities,
+    catalog: [malformedCapability],
+  })
+  assert.equal(
+    malformedCatalog.some((candidate) => candidate.id === malformedCapability.id),
+    false,
+  )
 })

--- a/tests/integration/test_workflow_opencli_hda_trace_api.py
+++ b/tests/integration/test_workflow_opencli_hda_trace_api.py
@@ -2111,13 +2111,18 @@ async def test_workflow_run_executes_live_http_sources(
     for node in project["nodes"]:
         if node["id"] in {"source-bilibili", "source-xhs"}:
             node["params"].pop("fixtureItems")
+        if node["id"] == "source-bilibili":
+            node["params"]["query"] = {"q": "OpenCLI"}
     project["adapters"] = [
         {
             "id": "opencli-bilibili",
             "type": "source",
             "provider": "http",
             "mode": "live",
-            "config": {"url": "https://feeds.example.test/bilibili"},
+            "config": {
+                "url": "https://feeds.example.test/bilibili",
+                "query": {"format": "json"},
+            },
         },
         {
             "id": "opencli-xhs",
@@ -2151,6 +2156,12 @@ async def test_workflow_run_executes_live_http_sources(
 
         async def request(self, method, url, **kwargs):
             assert method == "GET"
+            expected_query = (
+                {"format": "json", "q": "OpenCLI"}
+                if url.endswith("/bilibili")
+                else None
+            )
+            assert kwargs["params"] == expected_query
             return FakeResponse(live_payloads[url])
 
     async def fake_guarded_async_client(url, **kwargs):

--- a/tests/unit/test_workflow_osint_source_catalog.py
+++ b/tests/unit/test_workflow_osint_source_catalog.py
@@ -1,0 +1,100 @@
+from copy import deepcopy
+
+from backend.schemas.workflow import WorkflowProject
+from backend.workflow.capability_projection import build_workflow_capabilities
+from backend.workflow.compiler import compile_workflow_project
+from backend.workflow.runtime_registry import SOURCE_FETCH_BINDING_ID
+
+
+SOURCE_CASES = (
+    (
+        "intelligence.source.searxng",
+        {"endpoint": "https://search.example.test/search"},
+        "source-searxng-http",
+        "http",
+    ),
+    (
+        "intelligence.source.rsshub",
+        {"feedUrl": "https://rss.example.test/example/route"},
+        "source-rsshub-feed",
+        "rss",
+    ),
+)
+
+
+def _project_for_source(
+    capability_id: str,
+    required_params: dict[str, object],
+) -> WorkflowProject:
+    capability = next(
+        item for item in build_workflow_capabilities().catalog if item.id == capability_id
+    )
+    manifest = capability.manifest
+    adapter = deepcopy(manifest["nodeCatalog"]["adapter"])
+    params = {
+        parameter["name"]: deepcopy(parameter["default"])
+        for parameter in manifest["presentation"]["parameters"]
+        if "default" in parameter
+    }
+    params.update(required_params)
+    return WorkflowProject.model_validate(
+        {
+            "id": f"{capability_id}-round-trip",
+            "name": capability.label,
+            "profile": "intelligence",
+            "nodes": [
+                {
+                    "id": "source",
+                    "kind": capability.kind,
+                    "capability": capability.capability,
+                    "adapter": adapter["id"],
+                    "params": params,
+                    "ui": {"catalogId": capability.id, "label": capability.label},
+                }
+            ],
+            "edges": [],
+            "adapters": [adapter],
+            "agentPermissions": {
+                "canFetchNetwork": True,
+                "allowedDomains": ["search.example.test", "rss.example.test"],
+            },
+        }
+    )
+
+
+def test_osint_source_catalog_nodes_compile_to_existing_source_runtime():
+    for capability_id, required_params, adapter_id, provider in SOURCE_CASES:
+        project = _project_for_source(capability_id, required_params)
+
+        compiled = compile_workflow_project(project)
+
+        assert compiled.valid is True
+        assert compiled.errors == []
+        assert compiled.plan is not None
+        node = compiled.plan.runtime.nodes[0]
+        assert node.adapter is not None
+        assert node.adapter.id == adapter_id
+        assert node.adapter.provider == provider
+        assert node.runtime["binding"]["binding_id"] == SOURCE_FETCH_BINDING_ID
+        assert node.runtime.get("missing_runtime") is None
+
+
+def test_osint_source_catalog_nodes_are_backend_authoritative_and_editable():
+    catalog = {item.id: item for item in build_workflow_capabilities().catalog}
+
+    for capability_id, required_params, adapter_id, provider in SOURCE_CASES:
+        capability = catalog[capability_id]
+        manifest = capability.manifest
+        node_catalog = manifest["nodeCatalog"]
+        parameter_names = {
+            parameter["name"] for parameter in manifest["presentation"]["parameters"]
+        }
+
+        assert capability.status == "runnable"
+        assert capability.backendAvailable is True
+        assert manifest["canvas"]["node"] is True
+        assert node_catalog["authority"] == "backend"
+        assert node_catalog["category"] == "source"
+        assert node_catalog["adapter"]["id"] == adapter_id
+        assert node_catalog["adapter"]["provider"] == provider
+        assert set(required_params).issubset(parameter_names)

--- a/tests/unit/test_workflow_osint_source_catalog.py
+++ b/tests/unit/test_workflow_osint_source_catalog.py
@@ -5,7 +5,6 @@ from backend.workflow.capability_projection import build_workflow_capabilities
 from backend.workflow.compiler import compile_workflow_project
 from backend.workflow.runtime_registry import SOURCE_FETCH_BINDING_ID
 
-
 SOURCE_CASES = (
     (
         "intelligence.source.searxng",


### PR DESCRIPTION
## Outcome
- exposes SearXNG and RSSHub as backend-authoritative Canvas source presets
- materializes their existing HTTP/RSS adapters when the frontend adds a node
- merges adapter query defaults with per-node query parameters
- keeps network fetching behind the existing domain guard and workflow permissions

## Why this slice
This reuses the existing guarded HTTP and RSS executors. No new dependency or parallel execution framework is introduced.

## Verification
- backend source catalog projection + compile round trip
- frontend catalog-to-node adapter materialization regression
- live HTTP query merge integration regression
- existing grouped RSS integration regression

## Deferred deliberately
- Media Cloud: requires a credential resolver, rate-limit policy, and terms review before it can be truthfully marked runnable.
- local-loopback SearXNG: remains blocked by SSRF policy until a trusted Connection/Profile can opt into private addresses.