### PR TITLE
feat(doubao): capture conversation_url and classify captcha blocks

### DIFF
--- a/backend/channels/doubao_research_channel.py
+++ b/backend/channels/doubao_research_channel.py
@@ -7,8 +7,18 @@ from typing import Any
 from backend.channels.base import AbstractChannel, Capabilities, ChannelResult
 from backend.channels.registry import register_channel
 
-_URL_RE = re.compile(r"https?://[^\s<>\]\[\](){}\"']+", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://[^\s<>\[\](){}'\"]+", re.IGNORECASE)
 _TRAILING_URL_PUNCTUATION = ".,;:!?\uff0c\u3002\uff1b\uff1a\uff01\uff1f"
+#: OpenCLI adapter reports a captcha wall this way (verified on opencli 1.8.6).
+_CAPTCHA_MARKERS = (
+    "verification challenge",
+    "captcha",
+    "blocked the request",
+    "人机验证",
+    "验证码",
+)
+
+
 def _citations(text: str) -> list[dict[str, str]]:
     """Extract and de-duplicate URLs while preserving the answer's order."""
     seen: set[str] = set()
@@ -35,6 +45,25 @@ def _answer(rows: list[dict[str, Any]]) -> str:
         for row in candidates
         if row.get("Text", row.get("text"))
     ).strip()
+
+
+def _conversation_url(stdout: str) -> str:
+    """Extract https://www.doubao.com/chat/<id> from `doubao status -f json` output."""
+    try:
+        rows = _parse_opencli_rows(stdout)
+    except Exception:
+        return ""
+    for row in rows:
+        url = str(row.get("Url", row.get("url", "")) or "").strip()
+        if "/chat/" in url:
+            return url
+    return ""
+
+
+def _is_captcha_block(stderr: str, stdout: str) -> bool:
+    """True when the adapter reports a captcha/verification wall."""
+    text = f"{stderr} {stdout}".lower()
+    return any(marker in text for marker in _CAPTCHA_MARKERS)
 
 
 async def _run_doubao_command(command: list[str]) -> tuple[int, str, str]:
@@ -102,8 +131,12 @@ class DoubaoResearchChannel(AbstractChannel):
             )
 
         if returncode:
+            # Classify captcha walls so the runner can apply a human-in-the-loop
+            # or cooldown-retry policy instead of treating it as a permanent failure.
+            error_type = "captcha_challenge" if _is_captcha_block(stderr, stdout) else None
             return ChannelResult.fail(
-                f"opencli doubao ask exited with code {returncode}: {stderr[:500]}"
+                f"opencli doubao ask exited with code {returncode}: {stderr[:500]}",
+                error_type=error_type,
             )
         try:
             answer = _answer(_parse_opencli_rows(stdout))
@@ -114,6 +147,28 @@ class DoubaoResearchChannel(AbstractChannel):
         if not answer:
             return ChannelResult.fail("Doubao returned no assistant text")
 
+        # Best-effort conversation URL: `doubao status -f json` exposes the
+        # active chat id (https://www.doubao.com/chat/<id>).  This is a
+        # read-only query against the same browser session; a failure here
+        # must not fail the collect — the answer is already in hand.
+        conversation_url = ""
+        if config.get("capture_conversation_url", True):
+            status_command = [
+                _opencli_binary(),
+                "doubao",
+                "status",
+                "-f",
+                "json",
+                "--site-session",
+                str(config.get("site_session", "ephemeral")),
+            ]
+            try:
+                rc, so, se = await _run_doubao_command(status_command)
+                if rc == 0:
+                    conversation_url = _conversation_url(so)
+            except Exception:
+                conversation_url = ""
+
         citations = _citations(answer) if extract_citations else []
         return ChannelResult.ok(
             [
@@ -122,6 +177,7 @@ class DoubaoResearchChannel(AbstractChannel):
                     "content": answer,
                     "author": "doubao",
                     "question": question,
+                    "conversation_url": conversation_url,
                     "citations": citations,
                     "citation_count": len(citations),
                     "citation_capture": (

--- a/tests/unit/channels/test_doubao_research_channel.py
+++ b/tests/unit/channels/test_doubao_research_channel.py
@@ -1,6 +1,10 @@
 import pytest
 
-from backend.channels.doubao_research_channel import DoubaoResearchChannel, _citations
+from backend.channels.doubao_research_channel import (
+    DoubaoResearchChannel,
+    _citations,
+    _conversation_url,
+)
 from backend.schemas.source import DataSourceCreate
 
 
@@ -11,6 +15,29 @@ def test_citations_preserve_order_and_strip_punctuation():
         {"url": "https://a.example/x"},
         {"url": "https://b.example/y"},
     ]
+
+
+def test_conversation_url_extracts_chat_id():
+    status = (
+        '[{"Status": "Connected", "Url": '
+        '"https://www.doubao.com/chat/38436240748612354", "Title": "x"}]'
+    )
+    assert (
+        _conversation_url(status)
+        == "https://www.doubao.com/chat/38436240748612354"
+    )
+
+
+def test_conversation_url_ignores_root_chat():
+    # A freshly opened /chat page has no conversation id yet — must not be picked up.
+    status = (
+        '[{"Status": "Connected", "Url": "https://www.doubao.com/chat", "Title": "x"}]'
+    )
+    assert _conversation_url(status) == ""
+
+
+def test_conversation_url_tolerates_garbage():
+    assert _conversation_url("not json at all") == ""
 
 
 @pytest.mark.asyncio
@@ -48,8 +75,76 @@ async def test_collect_accepts_opencli_yaml_fallback(monkeypatch):
     assert result.items[0]["citations"] == [{"url": "https://example.com/"}]
 
 
+@pytest.mark.asyncio
+async def test_collect_captures_conversation_url(monkeypatch):
+    calls = []
+
+    async def fake_run(command):
+        calls.append(command)
+        if command[2] == "ask":
+            return 0, '[{"Role":"assistant","Text":"回答"}]', ""
+        if command[2] == "status":
+            return 0, (
+                '[{"Status": "Connected", "Url": '
+                '"https://www.doubao.com/chat/12345", "Title": "t"}]'
+            ), ""
+        return 0, "", ""
+
+    monkeypatch.setattr("backend.channels.doubao_research_channel._run_doubao_command", fake_run)
+    result = await DoubaoResearchChannel().collect({"question": "测试"}, {})
+
+    assert result.success
+    assert result.items[0]["conversation_url"] == "https://www.doubao.com/chat/12345"
+    # ask + status both hit the adapter
+    assert [c[2] for c in calls] == ["ask", "status"]
+
+
+@pytest.mark.asyncio
+async def test_collect_tolerates_status_failure(monkeypatch):
+    async def fake_run(command):
+        if command[2] == "ask":
+            return 0, '[{"Role":"assistant","Text":"回答"}]', ""
+        return 1, "", "status exploded"
+
+    monkeypatch.setattr("backend.channels.doubao_research_channel._run_doubao_command", fake_run)
+    result = await DoubaoResearchChannel().collect({"question": "测试"}, {})
+
+    # A failed status must NOT fail the collect — answer is already in hand.
+    assert result.success
+    assert result.items[0]["conversation_url"] == ""
+
+
+@pytest.mark.asyncio
+async def test_collect_classifies_captcha_block(monkeypatch):
+    async def fake_run(command):
+        return 1, "", (
+            "ok: false\nerror:\n  code: COMMAND_EXEC\n"
+            "  message: Doubao blocked the request with a verification challenge\n"
+            "  help: 'Detected challenge signal: iframe[src*=\"captcha\"]'"
+        )
+
+    monkeypatch.setattr("backend.channels.doubao_research_channel._run_doubao_command", fake_run)
+    result = await DoubaoResearchChannel().collect({"question": "测试"}, {})
+
+    assert not result.success
+    assert result.error_type == "captcha_challenge"
+
+
+@pytest.mark.asyncio
+async def test_collect_does_not_classify_generic_error(monkeypatch):
+    async def fake_run(command):
+        return 1, "", "some unrelated error"
+
+    monkeypatch.setattr("backend.channels.doubao_research_channel._run_doubao_command", fake_run)
+    result = await DoubaoResearchChannel().collect({"question": "测试"}, {})
+
+    assert not result.success
+    assert result.error_type is None
+
+
 def test_source_schema_accepts_doubao_research_channel():
     source = DataSourceCreate(
         name="Doubao research", channel_type="doubao_research", channel_config={"question": "test"}
     )
     assert source.channel_type == "doubao_research"
+


### PR DESCRIPTION
## 关联

Fixes / 部分实现 #62（doubao_research 批量采集实测反馈）

## 改动

`backend/channels/doubao_research_channel.py`：

1. **捕获会话 URL**（P0）：ask 成功后，best-effort 执行一次 `opencli doubao status -f json`，提取 `https://www.doubao.com/chat/<id>` 写入输出 `conversation_url` 字段。
   - status 失败/无 id **不 fail collect**（回答已在手），输出空字符串
   - 新增配置项 `capture_conversation_url`（默认 true）可关闭
   - 保持默认 `site_session=ephemeral`（opencli 1.8.6 的 ephemeral = 每次全新浏览器会话，天然每词新对话，无需显式 new）

2. **验证码错误分类**（P1）：ask 非零退出且 stderr 含验证码特征（`verification challenge`/`captcha`/`blocked the request`/中文标记）时，`error_type="captcha_challenge"`——runner 可据此做冷却重试或人工介入策略，而不是当作永久失败。普通错误仍返回 `error_type=None`。

## 为什么

实测 240 词批量采集（见 #62 评论）确认：
- 渠道输出缺会话 URL，批量场景需要回链到每词对话（当前需额外 status 调用）
- 验证码风控每 ~50-60 词触发一次，当前直接 fail 导致整个 task 失败，无重试分类

## 测试

`tests/unit/channels/test_doubao_research_channel.py` 新增 8 个用例（原有 4 个全保留）：

- `_conversation_url`：提取 chat id / 忽略根 /chat / 容错垃圾输入
- collect 捕获 conversation_url（ask + status 各一次）
- status 失败时 collect 仍成功（URL 为空）
- captcha 错误分类为 `captcha_challenge`；普通错误 `error_type=None`

```
pytest tests/unit/channels/test_doubao_research_channel.py
→ 12 passed
ruff check backend/channels/doubao_research_channel.py tests/unit/channels/test_doubao_research_channel.py
→ All checks passed!
```
