### PR TITLE
feat(notifications): wire on_ai_processed / on_task_failed trigger events

### DIFF
--- a/backend/pipeline/notifier_dispatch.py
+++ b/backend/pipeline/notifier_dispatch.py
@@ -93,10 +93,35 @@ async def dispatch_notifications(
     source_id: str,
     records: list[CollectedRecord],
     trigger_event: str = "on_new_record",
+    failure_payload: dict[str, Any] | None = None,
 ) -> dict[str, int]:
     """Find matching notification rules and dispatch. Returns ``{"sent": n,
     "failed": m}`` — the real aggregate outcome (AUDIT C12: this used to be
-    silent per-row-only bookkeeping the caller never inspected)."""
+    silent per-row-only bookkeeping the caller never inspected).
+
+    ``failure_payload`` lets the ``on_task_failed`` producer fire with NO
+    collected records: when ``records`` is empty and a failure payload is
+    given, a synthetic record (never persisted) is used so the normal
+    rule-matching / logging / send pipeline applies unchanged to task-failure
+    notifications.
+    """
+    if not records and failure_payload:
+        records = [
+            CollectedRecord(
+                task_id=str(failure_payload.get("task_id") or ""),
+                source_id=source_id,
+                raw_data={},
+                normalized_data={
+                    "title": f"Task failed: {source_id}",
+                    "error": failure_payload.get("error"),
+                    "error_type": failure_payload.get("error_type"),
+                    "source_id": source_id,
+                    "task_id": failure_payload.get("task_id"),
+                },
+                ai_enrichment=None,
+                content_hash=f"task-failed-{uuid.uuid4().hex}",
+            )
+        ]
     if not records:
         return {"sent": 0, "failed": 0}
 

--- a/backend/pipeline/pipeline.py
+++ b/backend/pipeline/pipeline.py
@@ -113,6 +113,36 @@ class PipelineResult:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
+async def _notify_task_failed(
+    task_id: str, source_id: str, *, error: str, error_type: str | None
+) -> None:
+    """Best-effort ``on_task_failed`` notification dispatch (W2 producer).
+
+    Fires matching notification rules with a synthetic failure payload so a
+    task failure can alert operators even though no records were collected.
+    Never masks the original failure — a notification error is logged and
+    swallowed.
+    """
+    try:
+        from backend.database import AsyncSessionLocal
+        from backend.pipeline import notifier_dispatch
+
+        async with AsyncSessionLocal() as session:
+            await notifier_dispatch.dispatch_notifications(
+                session,
+                source_id,
+                [],
+                trigger_event="on_task_failed",
+                failure_payload={
+                    "error": error,
+                    "error_type": error_type,
+                    "task_id": task_id,
+                },
+            )
+    except Exception:
+        logger.exception("[task:%s] failed to dispatch on_task_failed notification", task_id)
+
+
 async def run_pipeline(
     task_id: str,
     source: DataSource,
@@ -130,7 +160,6 @@ async def run_pipeline(
 
     started = datetime.now(timezone.utc)
     params = parameters or {}
-
     # Pre-step: auto-resolve chrome endpoint from a browser binding. Channels that
     # declare capabilities.session_affinity (opencli, skill) drive a real Chrome
     # from the shared pool, so a site-keyed binding lets them attach to a
@@ -239,6 +268,10 @@ async def run_pipeline(
                 error_kind=map_exception(exc),
                 raw={"stage": "collect", "error": str(exc), "error_type": error_type},
             )
+        if enable_notifications:
+            await _notify_task_failed(
+                task_id, source.id, error=str(exc), error_type=error_type
+            )
         return PipelineResult(success=False, source_id=source.id, error=str(exc))
 
     if not channel_result.success:
@@ -261,6 +294,13 @@ async def run_pipeline(
                 fetch_latency_ms=int((datetime.now(timezone.utc) - step1_start).total_seconds() * 1000),
                 error_type=channel_result.error_type,
                 raw={"stage": "collect", "error": channel_result.error},
+            )
+        if enable_notifications:
+            await _notify_task_failed(
+                task_id,
+                source.id,
+                error=channel_result.error or "collect failed",
+                error_type=channel_result.error_type,
             )
         return PipelineResult(success=False, source_id=source.id, error=channel_result.error)
 
@@ -503,6 +543,12 @@ async def run_pipeline(
                 notify_summary = await notifier_dispatch.dispatch_notifications(
                     session, source.id, new_records
                 )
+                # W2 producer: rules scoped to on_ai_processed fire when AI
+                # enrichment actually ran on this batch.
+                if ai_count > 0:
+                    await notifier_dispatch.dispatch_notifications(
+                        session, source.id, new_records, trigger_event="on_ai_processed"
+                    )
             notifications_sent = notify_summary.get("sent", 0)
             notifications_failed = notify_summary.get("failed", 0)
             # AUDIT C12: report the real aggregate, not an unconditional

--- a/backend/schemas/notification.py
+++ b/backend/schemas/notification.py
@@ -9,14 +9,14 @@ from backend.schemas.common import UTCModel
 class NotificationRuleCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     source_id: str | None = None
-    # WIRING_GAP_LEDGER W2: dispatch_notifications() only ever queries/fires
-    # rules with trigger_event == "on_new_record" (backend/pipeline/
-    # notifier_dispatch.py) — there is no producer for any other value.
-    # Before this Literal, a rule saved with any other string (the free-text
-    # str field previously accepted anything) became permanently, silently
-    # inert. Constrained here at the schema layer so the API rejects an
-    # unsupported value loudly instead of persisting a dead rule.
-    trigger_event: Literal["on_new_record"]
+    # WIRING_GAP_LEDGER W2 (resolved): dispatch_notifications() used to only
+    # query/fire rules with trigger_event == "on_new_record" with no producer
+    # for any other value. Producers now exist for all three values:
+    #   - on_new_record   — pipeline step 5 (every successful collect)
+    #   - on_ai_processed — pipeline step 5, when AI enrichment ran (ai_count>0)
+    #   - on_task_failed  — pipeline failure paths (collect exception / fail),
+    #                       with a synthetic failure payload
+    trigger_event: Literal["on_new_record", "on_ai_processed", "on_task_failed"]
     notifier_type: str
     notifier_config: dict[str, Any] = Field(default_factory=dict)
     filter_conditions: dict[str, Any] | None = None
@@ -25,7 +25,7 @@ class NotificationRuleCreate(BaseModel):
 
 class NotificationRuleUpdate(BaseModel):
     name: str | None = None
-    trigger_event: Literal["on_new_record"] | None = None
+    trigger_event: Literal["on_new_record", "on_ai_processed", "on_task_failed"] | None = None
     notifier_type: str | None = None
     notifier_config: dict[str, Any] | None = None
     filter_conditions: dict[str, Any] | None = None

--- a/tests/unit/pipeline/test_notifier_dispatch.py
+++ b/tests/unit/pipeline/test_notifier_dispatch.py
@@ -81,3 +81,100 @@ async def test_dispatch_with_matching_rule(db_session):
     logs = (await db_session.execute(select(NotificationLog))).scalars().all()
     assert len(logs) == 1
     assert logs[0].status == "sent"
+
+
+# ── trigger_event producers: on_ai_processed / on_task_failed ──────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_on_ai_processed_matches_event_scoped_rule(db_session):
+    """A rule with trigger_event='on_ai_processed' fires only when dispatch is
+    called with that event — and an on_new_record rule does NOT fire for it."""
+    from backend.models.notification import NotificationRule
+    from backend.models.source import DataSource
+
+    source = DataSource(
+        name="AI Source", channel_type="rss", channel_config={"feed_url": "https://ex.com/feed"}
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    db_session.add_all([
+        NotificationRule(
+            name="AI rule", trigger_event="on_ai_processed",
+            notifier_type="webhook", notifier_config={"url": "https://hooks.ex.com/ai"},
+            enabled=True,
+        ),
+        NotificationRule(
+            name="New rule", trigger_event="on_new_record",
+            notifier_type="webhook", notifier_config={"url": "https://hooks.ex.com/new"},
+            enabled=True,
+        ),
+    ])
+    await db_session.flush()
+
+    record = MagicMock()
+    record.id = "rec-ai-1"
+    record.normalized_data = {"title": "Enriched"}
+    record.ai_enrichment = {"summary": "s"}
+
+    mock_notifier = AsyncMock()
+    mock_notifier.send = AsyncMock(return_value=True)
+
+    with (
+        patch("backend.pipeline.notifier_dispatch.get_notifier", return_value=mock_notifier),
+        patch("backend.database.AsyncSessionLocal", return_value=_session_cm(db_session)),
+    ):
+        outcome = await dispatch_notifications(
+            db_session, source.id, [record], "on_ai_processed"
+        )
+
+    assert outcome == {"sent": 1, "failed": 0}
+    sent_payload = mock_notifier.send.await_args.args[1]
+    assert sent_payload.event == "on_ai_processed"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_on_task_failed_with_synthetic_payload(db_session):
+    """on_task_failed fires with NO collected records via failure_payload — the
+    synthetic record carries error/error_type into the notification payload."""
+    from backend.models.notification import NotificationRule
+    from backend.models.source import DataSource
+
+    source = DataSource(
+        name="Fail Source", channel_type="rss", channel_config={"feed_url": "https://ex.com/f"}
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    db_session.add(
+        NotificationRule(
+            name="Fail rule", trigger_event="on_task_failed",
+            notifier_type="webhook", notifier_config={"url": "https://hooks.ex.com/fail"},
+            enabled=True,
+        )
+    )
+    await db_session.flush()
+
+    mock_notifier = AsyncMock()
+    mock_notifier.send = AsyncMock(return_value=True)
+
+    with (
+        patch("backend.pipeline.notifier_dispatch.get_notifier", return_value=mock_notifier),
+        patch("backend.database.AsyncSessionLocal", return_value=_session_cm(db_session)),
+    ):
+        outcome = await dispatch_notifications(
+            db_session, source.id, [],
+            "on_task_failed",
+            failure_payload={
+                "error": "opencli doubao ask exited with code 1: captcha",
+                "error_type": "captcha_challenge",
+                "task_id": "task-9",
+            },
+        )
+
+    assert outcome == {"sent": 1, "failed": 0}
+    sent_payload = mock_notifier.send.await_args.args[1]
+    assert sent_payload.event == "on_task_failed"
+    assert "captcha" in sent_payload.data["error"]
+    assert sent_payload.data["error_type"] == "captcha_challenge"

--- a/tests/unit/pipeline/test_pipeline_errors.py
+++ b/tests/unit/pipeline/test_pipeline_errors.py
@@ -205,3 +205,101 @@ async def test_pipeline_sink_retryable_exception_propagates(db_session):
     ):
         with pytest.raises(ConnectionError, match="pool exhausted"):
             await run_pipeline(db_session, source, task.id)
+
+
+# ── notification trigger_event producers (W2): on_ai_processed / on_task_failed ──
+
+
+@pytest.mark.asyncio
+async def test_pipeline_failure_dispatches_on_task_failed_notification(db_session):
+    """A permanent collect failure fires the on_task_failed producer with the
+    error payload — and success paths never do."""
+    from backend.models.source import DataSource
+    from backend.models.task import CollectionTask
+
+    source = DataSource(
+        name="Notif Fail Source",
+        channel_type="rss",
+        channel_config={"feed_url": "https://ex.com/feed.xml"},
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    task = CollectionTask(source_id=source.id, trigger_type="manual", parameters={})
+    db_session.add(task)
+    await db_session.flush()
+
+    channel_result = ChannelResult.fail("feed malformed", error_type="JSONDecodeError")
+
+    with (
+        patch("backend.pipeline.collector.collect", return_value=channel_result),
+        patch(
+            "backend.pipeline.pipeline._notify_task_failed", new_callable=AsyncMock
+        ) as mock_notify,
+    ):
+        result = await run_pipeline(task.id, source)
+
+    assert result.success is False
+    mock_notify.assert_awaited_once()
+    assert mock_notify.await_args.kwargs["error"] == "feed malformed"
+    assert mock_notify.await_args.kwargs["error_type"] == "JSONDecodeError"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_ai_processed_dispatches_second_notification(db_session):
+    """When AI enrichment runs, step 5 fires BOTH on_new_record and
+    on_ai_processed; when it doesn't, only on_new_record fires."""
+    from backend.models.source import DataSource
+    from backend.models.task import CollectionTask
+
+    source = DataSource(
+        name="Notif AI Source",
+        channel_type="rss",
+        channel_config={"feed_url": "https://ex.com/feed.xml"},
+        ai_config={"processor_type": "claude"},
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    task = CollectionTask(source_id=source.id, trigger_type="manual", parameters={})
+    db_session.add(task)
+    await db_session.flush()
+
+    items = [{"title": "Item"}]
+    channel_result = ChannelResult.ok(items)
+    mock_records = [MagicMock(ai_enrichment={"summary": "s"})]
+
+    events = []
+
+    async def fake_dispatch(session, source_id, records, trigger_event="on_new_record", failure_payload=None):  # noqa: E501
+        events.append(trigger_event)
+        return {"sent": 0, "failed": 0}
+
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(return_value=source)
+    mock_session.commit = AsyncMock()
+    mock_session_cm = AsyncMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("backend.pipeline.collector.collect", return_value=channel_result),
+        patch(
+            "backend.pipeline.storer.store_records",
+            new=AsyncMock(return_value=(mock_records, 0)),
+        ),
+        patch("backend.database.AsyncSessionLocal", return_value=mock_session_cm),
+        patch(
+            "backend.pipeline.ai_processor.process_with_ai",
+            new=AsyncMock(return_value=1),
+        ),
+        patch(
+            "backend.pipeline.notifier_dispatch.dispatch_notifications",
+            side_effect=fake_dispatch,
+        ),
+    ):
+        result = await run_pipeline(task.id, source)
+
+    assert result.success is True
+    assert events.count("on_new_record") == 1
+    assert events.count("on_ai_processed") == 1

--- a/tests/unit/test_schemas_notification.py
+++ b/tests/unit/test_schemas_notification.py
@@ -22,19 +22,26 @@ class TestNotificationRuleCreateTriggerEvent:
         )
         assert rule.trigger_event == "on_new_record"
 
-    def test_unsupported_value_rejected(self):
-        """on_task_failed reads like a plausible trigger (it's even named in
-        the model's stale comment) but has no dispatch producer -- must be
-        rejected, not silently accepted into a dead rule."""
-        with pytest.raises(ValidationError):
-            NotificationRuleCreate(
-                name="r1", trigger_event="on_task_failed", notifier_type="webhook"
-            )
+    def test_on_ai_processed_accepted(self):
+        """on_ai_processed now has a dispatch producer (pipeline step 5 when
+        AI enrichment ran) — accepted at the schema layer."""
+        rule = NotificationRuleCreate(
+            name="r1", trigger_event="on_ai_processed", notifier_type="webhook"
+        )
+        assert rule.trigger_event == "on_ai_processed"
+
+    def test_on_task_failed_accepted(self):
+        """on_task_failed now has a dispatch producer (pipeline failure paths
+        with a synthetic failure payload) — accepted at the schema layer."""
+        rule = NotificationRuleCreate(
+            name="r1", trigger_event="on_task_failed", notifier_type="webhook"
+        )
+        assert rule.trigger_event == "on_task_failed"
 
     def test_arbitrary_string_rejected(self):
         with pytest.raises(ValidationError):
             NotificationRuleCreate(
-                name="r1", trigger_event="on_ai_processed", notifier_type="webhook"
+                name="r1", trigger_event="on_something_else", notifier_type="webhook"
             )
 
     def test_missing_trigger_event_still_required(self):
@@ -49,9 +56,13 @@ class TestNotificationRuleUpdateTriggerEvent:
         update = NotificationRuleUpdate(trigger_event="on_new_record")
         assert update.trigger_event == "on_new_record"
 
+    def test_on_task_failed_accepted(self):
+        update = NotificationRuleUpdate(trigger_event="on_task_failed")
+        assert update.trigger_event == "on_task_failed"
+
     def test_unsupported_value_rejected(self):
         with pytest.raises(ValidationError):
-            NotificationRuleUpdate(trigger_event="on_task_failed")
+            NotificationRuleUpdate(trigger_event="on_whatever")
 
     def test_omitted_trigger_event_stays_none(self):
         """Update is a partial patch -- omitting trigger_event entirely must


### PR DESCRIPTION
## Summary
WIRING_GAP_LEDGER W2: the model comment promised `trigger_event` of `on_new_record | on_ai_processed | on_task_failed` but the schema Literal only allowed `on_new_record` and `dispatch_notifications()` had **no producer** for any other value — a rule saved with another string was rejected at the schema layer, but the promised events stayed impossible.

## Changes
- `schemas/notification`: Literal now accepts all three values (Create + Update); arbitrary strings still rejected (422)
- `notifier_dispatch`: `dispatch_notifications()` gains `failure_payload` — with no collected records and a failure payload, a synthetic (never-persisted) record carries error/error_type into the normal rule-match/send pipeline, so `on_task_failed` fires without any collected items
- `pipeline`: step 5 fires `on_ai_processed` when AI enrichment ran (`ai_count>0`) after the existing `on_new_record` dispatch; both permanent collect-failure paths call a new best-effort `_notify_task_failed()` helper (error + error_type + task_id), guarded by `enable_notifications` and never masking the original failure

## Test Plan
- schema accepts 3 values / rejects arbitrary (Create + Update)
- dispatch event-scoped rule matching for `on_ai_processed` (on_new_record rule does NOT fire)
- `on_task_failed` synthetic payload with error fields
- pipeline wiring: failure fires `_notify_task_failed` with error/error_type; AI run fires both events

42 passed on affected suites; ruff errors unchanged vs baseline (19).