### PR TITLE
fix(channels): wire SCHEMA_DRIFT error_type for api/crawl4ai JSON parse failures

### DIFF
--- a/backend/channels/api_channel.py
+++ b/backend/channels/api_channel.py
@@ -119,7 +119,12 @@ class ApiChannel(AbstractChannel):
         try:
             data = response.json()
         except Exception as exc:
-            raise ChannelFetchError("Failed to parse API response as JSON") from exc
+            # WIRING_GAP_LEDGER W1: error_type must be set so the SCHEMA_DRIFT
+            # chain (error_kinds -> control.recorder) fires instead of being
+            # dropped by recorder's `elif error_type is not None` guard.
+            raise ChannelFetchError(
+                "Failed to parse API response as JSON", error_type=type(exc).__name__
+            ) from exc
 
         if result_path:
             for key in result_path.split("."):

--- a/backend/channels/crawl4ai_channel.py
+++ b/backend/channels/crawl4ai_channel.py
@@ -137,8 +137,13 @@ class Crawl4AIChannel(AbstractChannel):
             try:
                 parsed = json.loads(result.extracted_content)
             except (json.JSONDecodeError, TypeError) as exc:
+                # WIRING_GAP_LEDGER W1: error_type must be set so the
+                # SCHEMA_DRIFT chain (error_kinds -> control.recorder) fires
+                # instead of being dropped by recorder's `elif error_type is
+                # not None` guard.
                 raise ChannelFetchError(
-                    "crawl4ai: could not parse extracted_content as JSON"
+                    "crawl4ai: could not parse extracted_content as JSON",
+                    error_type=type(exc).__name__,
                 ) from exc
             items = parsed if isinstance(parsed, list) else [parsed]
 

--- a/tests/unit/channels/test_api_channel.py
+++ b/tests/unit/channels/test_api_channel.py
@@ -7,6 +7,7 @@ import pytest
 
 from backend.channels.api_channel import ApiChannel, _resolve_dict_secrets, _resolve_secrets
 from backend.channels.base import ChannelFetchError, FetchContext
+from backend.control.error_kinds import ErrorKind, map_error_type
 
 
 @pytest.fixture(autouse=True)
@@ -645,6 +646,59 @@ async def test_fetch_http_error_raises_channel_fetch_error(channel):
 
     with pytest.raises(ChannelFetchError, match="500"):
         await channel.fetch(ctx)
+
+
+# ── WIRING_GAP_LEDGER W1: JSON parse failures must carry error_type so the
+# SCHEMA_DRIFT chain (error_kinds -> control.recorder) fires instead of being
+# dropped by recorder's `elif error_type is not None` guard. ────────────────
+
+@pytest.mark.asyncio
+async def test_fetch_non_json_response_classified_schema_drift(channel):
+    """fetch() JSON parse failure carries error_type mapping to SCHEMA_DRIFT."""
+    import json
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = MagicMock(
+        side_effect=json.JSONDecodeError("Expecting value", "doc", 0)
+    )
+    http = AsyncMock()
+    http.request = AsyncMock(return_value=mock_response)
+    ctx = FetchContext(
+        config={"base_url": "https://api.example.com", "endpoint": "/data"},
+        params={},
+        http=http,
+    )
+
+    with pytest.raises(ChannelFetchError) as exc_info:
+        await channel.fetch(ctx)
+
+    assert exc_info.value.error_type == "JSONDecodeError"
+    assert map_error_type(exc_info.value.error_type) is ErrorKind.SCHEMA_DRIFT
+
+
+@pytest.mark.asyncio
+async def test_collect_non_json_response_classified_schema_drift(channel):
+    """collect() propagates fetch()'s error_type through ChannelResult.fail."""
+    import json
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = MagicMock(
+        side_effect=json.JSONDecodeError("Expecting value", "doc", 0)
+    )
+    mock_client_ctx, _ = _make_mock_client(mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client_ctx):
+        result = await channel.collect(
+            {"base_url": "https://api.example.com", "endpoint": "/data"}, {}
+        )
+
+    assert result.success is False
+    assert result.error_type == "JSONDecodeError"
+    assert map_error_type(result.error_type) is ErrorKind.SCHEMA_DRIFT
 
 
 # ── AUDIT C13: gateway statuses classify retryable, other 4xx stay permanent ──

--- a/tests/unit/channels/test_crawl4ai_channel.py
+++ b/tests/unit/channels/test_crawl4ai_channel.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from backend.channels.base import ChannelFetchError, FetchContext
 from backend.channels.crawl4ai_channel import Crawl4AIChannel
+from backend.control.error_kinds import ErrorKind, map_error_type
 
 
 def _sessionmaker(db_engine):
@@ -127,8 +128,14 @@ async def test_fetch_malformed_extracted_content_raises(channel):
         config={"url": "https://example.com", "selectors": {"title": "h1"}}, params={}
     )
     with patch("crawl4ai.AsyncWebCrawler", return_value=ctx_mgr):
-        with pytest.raises(ChannelFetchError, match="could not parse extracted_content"):
+        with pytest.raises(ChannelFetchError) as exc_info:
             await channel.fetch(ctx)
+
+    # WIRING_GAP_LEDGER W1: parse failures must carry error_type so the
+    # SCHEMA_DRIFT chain (error_kinds -> control.recorder) fires instead of
+    # being dropped by recorder's `elif error_type is not None` guard.
+    assert exc_info.value.error_type == "JSONDecodeError"
+    assert map_error_type(exc_info.value.error_type) is ErrorKind.SCHEMA_DRIFT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

WIRING_GAP_LEDGER **W1** (the ledger's highest-ROI item): the control layer's SCHEMA_DRIFT chain (`error_kinds` → `evaluator` → `policies` → `actuator`) runs every 60s, but only fires when a channel passes `error_type` explicitly — `control/recorder.py` drops failures with `error_type is None` (the `elif error_type is not None` guard).

Two JSON parse failure points still raised `ChannelFetchError` **without** `error_type`, so a schema drift in those channels looked like a healthy source:

- `api_channel.py` — `response.json()` parse failure
- `crawl4ai_channel.py` — `extracted_content` JSON parse failure

## Change

Set `error_type=type(exc).__name__` at both points. `JSONDecodeError` already maps to `SCHEMA_DRIFT` in `backend/control/error_kinds.py`, so the failure now reaches the recorder and the 60s control chain fires.

(The rss/cli parse points of W1 were already wired in #60 / the pending rss empty-HTML PR; this closes the remaining channel surface.)

## Verification

- New tests: JSONDecodeError → SCHEMA_DRIFT for api `fetch()` and `collect()` paths, and crawl4ai malformed `extracted_content`
- Targeted: 76 passed (api + crawl4ai suites)
- Full regression: **2704 passed, 50 skipped**, coverage 88.42% (≥80% gate)
- ruff: 6 errors = identical to origin/main baseline (net-new 0; pre-existing E501/F841)

Closes the W1 portion of #31.