### PR TITLE
feat(control): control center — kill switch, advisory, ODP, audit + Operate-surface design

### DIFF
--- a/frontend/app/(app)/control/page.tsx
+++ b/frontend/app/(app)/control/page.tsx
@@ -9,6 +9,7 @@ import {
   useKillSwitch,
   useOdpState,
   useSetKillSwitch,
+  useSystemConfig,
 } from '@/lib/api/hooks'
 import { BACKEND_HINT, EmptyState, ErrorState, LoadingState } from '@/components/shell/data-states'
 import { StatusBadge } from '@/components/shell/status-badge'
@@ -224,9 +225,12 @@ function OdpGrid({ state }: { state: OdpSystemState }) {
               ? '—'
               : `${state.store.heartbeat_age_seconds}s`}
           </span>
-          {state.store.note ? (
-            <span className="truncate text-3xs text-muted-foreground" title={state.store.note}>
-              {state.store.note}
+          {state.store.note ?? state.store.error ? (
+            <span
+              className="truncate text-3xs text-muted-foreground"
+              title={state.store.note ?? state.store.error ?? undefined}
+            >
+              {state.store.note ?? state.store.error}
             </span>
           ) : null}
         </OdpCell>
@@ -234,9 +238,12 @@ function OdpGrid({ state }: { state: OdpSystemState }) {
           <span className="font-mono text-xs">
             {state.outbox.unpublished == null ? '—' : formatNum(state.outbox.unpublished)}
           </span>
-          {state.outbox.note ? (
-            <span className="truncate text-3xs text-muted-foreground" title={state.outbox.note}>
-              {state.outbox.note}
+          {state.outbox.note ?? state.outbox.error ? (
+            <span
+              className="truncate text-3xs text-muted-foreground"
+              title={state.outbox.note ?? state.outbox.error ?? undefined}
+            >
+              {state.outbox.note ?? state.outbox.error}
             </span>
           ) : null}
         </OdpCell>
@@ -246,17 +253,6 @@ function OdpGrid({ state }: { state: OdpSystemState }) {
       </span>
     </div>
   )
-}
-
-/* ────────────────────────────────────────────────────────────────
- * Advisory report — the automation-gate data. Buckets carry a gate
- * badge: mostly-recovered buckets must NOT be automated, mostly-
- * persisted ones qualify.
- * ──────────────────────────────────────────────────────────────── */
-
-function gateEligible(bucket: AdvisoryReport['buckets'][number]): boolean {
-  if (bucket.recovery_rate == null) return false
-  return bucket.recovery_rate < 0.8 && bucket.persisted > 0
 }
 
 function AdvisoryTotalsRow({ report }: { report: AdvisoryReport }) {
@@ -413,6 +409,7 @@ export default function ControlCenterPage() {
   const setKill = useSetKillSwitch()
   const advisory = useAdvisoryReport({ refetchInterval: 60_000 })
   const odp = useOdpState({ refetchInterval: 15_000 })
+  const config = useSystemConfig()
   const ledger = useControlActions({ page: 1, limit: PAGE_SIZE })
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [killFeedback, setKillFeedback] = useState<{
@@ -460,7 +457,15 @@ export default function ControlCenterPage() {
   const odpAvailable = odp.data
     ? [odp.data.ingest.available, odp.data.stream.available, odp.data.dlq.available, odp.data.store.available, odp.data.outbox.available].filter(Boolean).length
     : null
-  const qualifiedBuckets = advisory.data?.buckets.filter(gateEligible).length ?? null
+  const automationGateLabel = config.data
+    ? config.data.control_mode === 'automatic'
+      ? kill.data?.engaged
+        ? '自动模式 · 熔断阻断'
+        : '自动模式 · 配置门禁'
+      : '建议模式 · 仅咨询'
+    : advisory.data
+      ? 'Advisory 证据 · 配置门禁'
+      : '—'
   const ledgerTotal = ledger.data?.meta?.total ?? null
 
   return (
@@ -481,8 +486,9 @@ export default function ControlCenterPage() {
         />
         <StripCell
           label="自动化门禁"
-          value={qualifiedBuckets == null ? '—' : `${qualifiedBuckets} 类可自动化`}
-          dotTone={qualifiedBuckets && qualifiedBuckets > 0 ? 'warn' : 'muted'}
+          value={automationGateLabel}
+          dot
+          dotTone={kill.data?.engaged ? 'bad' : advisory.data ? 'warn' : 'muted'}
         />
         <StripCell
           label="ODP 数据面"
@@ -548,8 +554,7 @@ export default function ControlCenterPage() {
         <CardHeader>
           <CardTitle className="text-base">咨询报告（Advisory Report）</CardTitle>
           <CardDescription>
-            control_actions 证据台账的收敛/恢复统计。某 (state, action_type) 组合的建议大多「已恢复」说明过度建议，不应自动化；大多「已固化」才具备翻转 automatic 的门禁资格。读取时自动完成一次懒评估。
-          </CardDescription>
+            control_actions 证据台账的收敛/恢复统计。这里仅展示 advisory 证据，不在前端自行推断是否可自动化；automatic 是否允许由服务端配置门禁统一判定。
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           {advisory.isLoading ? (
@@ -598,13 +603,7 @@ export default function ControlCenterPage() {
                             {b.recovery_rate == null ? '—' : `${(b.recovery_rate * 100).toFixed(1)}%`}
                           </TableCell>
                           <TableCell>
-                            {gateEligible(b) ? (
-                              <Badge variant="outline" className="text-success">
-                                可自动化
-                              </Badge>
-                            ) : (
-                              <span className="text-3xs text-muted-foreground">不宜自动化</span>
-                            )}
+                            <Badge variant="outline">服务端配置门禁</Badge>
                           </TableCell>
                         </TableRow>
                       ))}

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -756,13 +756,15 @@ export interface OdpStoreHealth {
   available: boolean;
   healthy: boolean | null;
   heartbeat_age_seconds: number | null;
-  note: string;
+  note: string | null;
+  error?: string | null;
 }
 
 export interface OdpOutboxState {
   available: boolean;
   unpublished: number | null;
-  note: string;
+  note: string | null;
+  error?: string | null;
 }
 
 export interface OdpSystemState {


### PR DESCRIPTION
## 做什么

把**已建好但零 UI** 的三个 control-plane 端点接成一个操作面板（/control 控制中心），并做了一轮全量优化：

| 端点 | 面板 |
|---|---|
| GET/POST `/control/kill-switch` | 执行熔断开关：切换 + 生效来源（运行期覆盖 vs 配置默认）+ **开启需确认对话框**（危险操作防误触） |
| GET `/control/advisory-report` | 咨询报告：totals / 恢复率 / (state, action_type) 分桶表 / 模式分布 |
| GET `/control/odp-state` | ODP 数据面：ingest / stream / DLQ / store / outbox 健康，按区块降级 + 错误原因展示 |
| GET `/control/actions` | **审计台账（第 4 面板）**：分页表格 + 手动刷新 |

对应 WIRING_GAP_LEDGER W3（control-plane 操作面板 UI——后端+client 早已就绪，差最后一公里 UI）。

## 全量优化点

- **审计台账面板**：control_actions 分页（10/页），列 action/state/mode/executed/outcome/reason/time，共 X 条 · 第 X/X 页
- **危险操作确认**：开启熔断弹 Dialog 确认（红色警告全局短路影响）；关闭熔断保持一键
- **自动刷新**：kill-switch 30s / ODP 15s / advisory 60s（hooks 支持 refetchInterval 选项）
- **数值人性化**：oldest_pending_idle_ms → ms/s/min、大数千分位
- **区块降级提示**：store/outbox 的 note 字段透出（如 "ODP_INGEST_URL not configured"）

## 改动

- `frontend/app/(app)/control/page.tsx`（新，20KB）：四面板页面
- `frontend/lib/api/hooks.ts`：+4 hooks（useKillSwitch / useSetKillSwitch / useAdvisoryReport / useOdpState），支持 refetchInterval
- `frontend/lib/navigation.ts`：sidebar match + ROUTE_LABELS 注册 /control
- `frontend/scripts/check-control-plane-regressions.mjs`：回归契约断言

## 验证（真实数据链路已通）

- ✅ `pnpm exec tsc --noEmit` exit 0
- ✅ `pnpm exec eslint`（4 文件）0 error 0 warning
- ✅ `npm run check:control-plane`：新增 test 通过（1 个既有失败 `studio node selector` 为上游遗留，stash 验证与本次改动无关）
- ✅ dev server 实测 `GET /control` → 200；带 token 实测 4 端点全部返回真实数据（kill-switch 未熔断 / advisory 0 台账 / odp 区块降级 / actions 分页 meta）

## 备注

kill-switch 为有副作用的全局熔断，UI 上开启强制确认；advisory 报告只读不执行（后端每次读取自带懒评估）。本地开发用 `NEXT_PUBLIC_API_AUTH_TOKEN`（gitignored .env.local）或浏览器 localStorage `apiAuthToken` 注入 token。