### PR TITLE
feat(chat): wire chat role into ProviderResolver.resolve_with_fallback (#55)

### DIFF
--- a/backend/api/v1/chat.py
+++ b/backend/api/v1/chat.py
@@ -23,6 +23,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.control.agent_control import ACTION_REGISTRY, agent_control_service
 from backend.database import get_db
+from backend.llm import ResolverError, resolver
+from backend.llm.base import LlmAdapterError, classify_retryable
 from backend.models.provider import ModelProvider
 from backend.schemas.common import ApiResponse
 from backend.security.identity import RequestIdentity, get_request_identity
@@ -341,16 +343,25 @@ async def _build_proposal(
     )
 
 
-@router.post("", response_model=ApiResponse[ChatReply])
-async def chat(
+async def _chat_with_client(
+    client: Any,
+    model: str,
     body: ChatRequest,
-    identity: RequestIdentity | None = Depends(_optional_request_identity),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession,
+    identity: RequestIdentity | None,
 ) -> ApiResponse:
-    provider = await _pick_provider(db, body.provider_id)
-    client = await _build_client(provider)
-    model = provider.default_model or "gpt-4o-mini"
+    """Run the agent-dock tool loop against ``client`` with ``model``.
 
+    Extracted from the ``chat`` endpoint so the same loop serves both the
+    legacy single-provider path and each candidate tried inside
+    ``ProviderResolver.resolve_with_fallback`` (model-provider runtime
+    PR-E, issue #55). LLM-call failures are re-raised as
+    :class:`~backend.llm.base.LlmAdapterError` carrying
+    :func:`~backend.llm.base.classify_retryable`'s connection-vs-business
+    split (decision #7) — the resolver only fails over connection-level
+    failures, and the HTTP 502 conversion happens once at the endpoint
+    boundary instead of being baked into the loop.
+    """
     system = SYSTEM_PROMPT
     if body.context:
         system += f"\n\n当前用户操作上下文 (JSON): {json.dumps(body.context, ensure_ascii=False)}"
@@ -366,9 +377,13 @@ async def chat(
             response = await client.chat.completions.create(
                 model=model, messages=messages, tools=TOOLS, tool_choice="auto"
             )
+        except LlmAdapterError:
+            raise
         except Exception as exc:
             logger.error("chat llm error | %s", exc)
-            raise HTTPException(status_code=502, detail=f"模型调用失败: {exc}") from exc
+            raise LlmAdapterError(
+                f"chat llm error: {exc}", retryable=classify_retryable(exc)
+            ) from exc
 
         msg = response.choices[0].message
         tool_calls = msg.tool_calls or []
@@ -411,6 +426,61 @@ async def chat(
             )
 
     return ApiResponse.ok(ChatReply(type="message", content="(达到工具调用步数上限, 请换个说法再试)"))
+
+
+async def _chat_single_provider(
+    db: AsyncSession,
+    body: ChatRequest,
+    identity: RequestIdentity | None,
+    provider_id: Optional[str],
+) -> ApiResponse:
+    """Legacy pre-failover chat path (issue #55): one provider — the
+    explicit ``provider_id`` or the first enabled one — no candidate
+    failover. Kept as the fallback when the ``chat`` role has no
+    ``model_defaults.candidates`` configured, so existing installs behave
+    exactly as before the failover wiring.
+    """
+    provider = await _pick_provider(db, provider_id)
+    client = await _build_client(provider)
+    model = provider.default_model or "gpt-4o-mini"
+    return await _chat_with_client(client, model, body, db, identity)
+
+
+@router.post("", response_model=ApiResponse[ChatReply])
+async def chat(
+    body: ChatRequest,
+    identity: RequestIdentity | None = Depends(_optional_request_identity),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse:
+    """Agent dock chat (model-provider runtime PR-E, issue #55).
+
+    Provider selection now runs through
+    :func:`backend.llm.resolver.ProviderResolver.resolve_with_fallback` for
+    the ``chat`` role whenever ``model_defaults.candidates`` are configured
+    for it: candidates are tried in order and a connection-level failure
+    (connect error / timeout / 5xx — decision #7) fails over to the next
+    candidate, while a business failure (4xx: bad key, malformed request)
+    is re-raised immediately. An explicit ``provider_id`` still bypasses
+    failover (the user picked that provider on purpose), and a role with no
+    candidates falls back to the legacy first-enabled-provider lookup.
+    """
+    if body.provider_id or not await resolver.has_candidates(db, "chat"):
+        return await _chat_single_provider(db, body, identity, body.provider_id)
+
+    async def operation(adapter: Any, model_id: str) -> ApiResponse:
+        provider = adapter.provider
+        client = await _build_client(provider)
+        model = model_id or provider.default_model or "gpt-4o-mini"
+        return await _chat_with_client(client, model, body, db, identity)
+
+    try:
+        return await resolver.resolve_with_fallback(db, "chat", operation)
+    except (LlmAdapterError, ResolverError) as exc:
+        # Business-level failure (re-raised immediately, no candidate left
+        # untried) or every candidate skipped/failed → single 502 explaining
+        # why; never leaks a provider api_key (adapters sanitize).
+        logger.error("chat failover | %s", exc)
+        raise HTTPException(status_code=502, detail=f"模型调用失败: {exc}") from exc
 
 
 @router.post("/confirm", response_model=ApiResponse[dict])
@@ -502,9 +572,13 @@ async def _chat_xml(
     for _step in range(MAX_TOOL_STEPS):
         try:
             response = await client.chat.completions.create(model=model, messages=messages, max_tokens=1024)
+        except LlmAdapterError:
+            raise
         except Exception as exc:
             logger.error("chat(xml) llm error | %s", exc)
-            raise HTTPException(status_code=502, detail=f"模型调用失败: {exc}") from exc
+            raise LlmAdapterError(
+                f"chat(xml) llm error: {exc}", retryable=classify_retryable(exc)
+            ) from exc
 
         content = response.choices[0].message.content or ""
         calls = _parse_tool_use(content)

--- a/backend/llm/resolver.py
+++ b/backend/llm/resolver.py
@@ -102,24 +102,37 @@ class ProviderResolver:
             return []
         return list(row.candidates or [])
 
+    async def has_candidates(self, db: AsyncSession, role: str) -> bool:
+        """``True`` iff a non-empty ``model_defaults.candidates`` list exists
+        for ``role``.
+
+        A cheap pre-check for callers that want to keep a legacy fallback
+        path when the role has no failover order configured (e.g.
+        ``chat.py``: candidates configured → failover runtime; no candidates
+        → the pre-failover single-provider lookup, so existing installs
+        keep working unchanged).
+        """
+        return bool(await self._candidates_for(db, role))
+
     async def resolve(self, db: AsyncSession, role: str) -> ResolvedModel | None:
         """Return the primary (first) candidate configured for ``role``.
 
         Returns ``None`` — rather than raising — when no ``model_defaults``
-        row exists for ``role``, its ``candidates`` list is empty, or the
+        row exists for ``role``, its ``candidates`` list is empty, the
         first candidate's ``provider_id`` no longer resolves to a real
-        provider row: this is a direct "what's configured" lookup for
-        callers that want the single default, not a "try until one works"
-        search (that's :meth:`resolve_with_fallback`) — there is nothing to
-        fail over to here, so a clean ``None`` is more useful to a caller
-        than an exception for what is often just "nothing configured yet".
+        provider row, or that provider is currently disabled: this is a
+        direct "what's configured AND usable" lookup for callers that want
+        the single default, not a "try until one works" search (that's
+        :meth:`resolve_with_fallback`) — there is nothing to fail over to
+        here, so a clean ``None`` is more useful to a caller than an
+        exception for what is often just "nothing configured yet".
         """
         candidates = await self._candidates_for(db, role)
         if not candidates:
             return None
         candidate = candidates[0]
         provider = await db.get(ModelProvider, candidate["provider_id"])
-        if provider is None:
+        if provider is None or not provider.enabled:
             return None
         return ResolvedModel(
             provider=provider,
@@ -140,7 +153,10 @@ class ProviderResolver:
         - A candidate whose ``provider_id`` no longer resolves to a real
           provider row (deleted since the default was configured) is
           skipped the same way, without being put in cooldown (there is no
-          "it" to cool down).
+          "it" to cool down). A candidate whose provider row is currently
+          ``enabled=False`` is skipped identically — disabling a provider
+          in governance is an operator choice, not a liveness failure, so
+          it must not be used and must not go into cooldown either.
         - ``operation`` succeeding returns that result immediately — no
           further candidates are tried.
         - ``operation`` raising :class:`~backend.llm.base.LlmAdapterError`
@@ -169,6 +185,11 @@ class ProviderResolver:
             if provider is None:
                 # Candidate references a since-deleted provider — dead, but
                 # not "this provider just failed", so no cooldown to set.
+                continue
+            if not provider.enabled:
+                # Disabled in governance — an operator choice, not a
+                # liveness failure: skip without cooldown, same as a
+                # deleted provider.
                 continue
             adapter = get_adapter(provider)
             tried += 1

--- a/tests/integration/test_chat_failover_api.py
+++ b/tests/integration/test_chat_failover_api.py
@@ -1,0 +1,282 @@
+"""Production call-chain tests for issue #55: the agent dock ``POST
+/api/v1/chat`` endpoint routed through ``ProviderResolver.resolve_with_fallback``
+for the ``chat`` role.
+
+The only mocked seam is the network boundary — ``backend.api.v1.chat._build_client``
+is replaced with fake OpenAI-compatible clients whose ``chat.completions.create``
+can be scripted to raise SDK exceptions. Everything else (HTTP endpoint,
+``model_defaults`` candidates, resolver failover/cooldown, provider rows,
+legacy fallback) runs for real, so these prove the wiring the resolver unit
+tests cannot: that a configured failover order actually drives the production
+chat path, and that installs without candidates keep the pre-failover
+behavior.
+"""
+
+import httpx
+import openai
+import pytest
+
+from backend.llm.resolver import ProviderResolver
+
+
+# ── fake OpenAI-compatible client (network seam) ────────────────────────────
+class _FakeMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.tool_calls = []
+
+
+class _FakeChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeCompletions:
+    def __init__(self, exc: Exception | None, content: str) -> None:
+        self._exc = exc
+        self._content = content
+
+    async def create(self, **kwargs):
+        if self._exc is not None:
+            raise self._exc
+        return _FakeResponse(self._content)
+
+
+class _FakeChat:
+    def __init__(self, exc: Exception | None, content: str) -> None:
+        self.completions = _FakeCompletions(exc, content)
+
+
+class _FakeClient:
+    def __init__(self, exc: Exception | None, content: str) -> None:
+        self.chat = _FakeChat(exc, content)
+
+
+def _connection_error() -> openai.APIConnectionError:
+    request = httpx.Request("POST", "http://fake-provider/chat/completions")
+    return openai.APIConnectionError(request=request)
+
+
+def _auth_error() -> openai.AuthenticationError:
+    request = httpx.Request("POST", "http://fake-provider/chat/completions")
+    response = httpx.Response(401, request=request)
+    return openai.AuthenticationError("401 bad key", response=response, body=None)
+
+
+# ── setup helpers (real API path) ───────────────────────────────────────────
+async def _create_provider(client, *, name: str, enabled: bool = True) -> str:
+    resp = await client.post(
+        "/api/v1/providers",
+        json={
+            "name": name,
+            "provider_type": "openai",
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-test-key",
+            "default_model": "gpt-4o-mini",
+            "enabled": enabled,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["data"]["id"]
+
+
+async def _register_model(client, provider_id: str, model_id: str) -> None:
+    resp = await client.post(f"/api/v1/providers/{provider_id}/models", json={"model_id": model_id})
+    assert resp.status_code == 201, resp.text
+
+
+async def _put_chat_defaults(client, candidates: list[dict]) -> None:
+    resp = await client.put("/api/v1/model-defaults/chat", json={"candidates": candidates})
+    assert resp.status_code == 200, resp.text
+
+
+def _patch_network(monkeypatch, behavior: dict[str, Exception | str]):
+    """behavior: provider_id -> str (success content) or Exception (raised)."""
+    built: list[str] = []
+
+    async def fake_build(provider):
+        built.append(provider.id)
+        value = behavior[provider.id]
+        if isinstance(value, Exception):
+            return _FakeClient(exc=value, content="")
+        return _FakeClient(exc=None, content=value)
+
+    monkeypatch.setattr("backend.api.v1.chat._build_client", fake_build)
+    # isolate cooldown state per test (the module singleton would persist it)
+    monkeypatch.setattr("backend.api.v1.chat.resolver", ProviderResolver())
+    return built
+
+
+async def _chat(client, message: str = "hi") -> httpx.Response:
+    payload = {"messages": [{"role": "user", "content": message}]}
+    return await client.post("/api/v1/chat", json=payload)
+
+
+# ── legacy path: no model_defaults configured ───────────────────────────────
+def _patch_network_with_default(monkeypatch, behavior: dict[str, Exception | str], default: str):
+    """Like _patch_network, but providers absent from ``behavior`` succeed with ``default``."""
+    built: list[str] = []
+
+    async def fake_build(provider):
+        built.append(provider.id)
+        value = behavior.get(provider.id, default)
+        if isinstance(value, Exception):
+            return _FakeClient(exc=value, content="")
+        return _FakeClient(exc=None, content=value)
+
+    monkeypatch.setattr("backend.api.v1.chat._build_client", fake_build)
+    monkeypatch.setattr("backend.api.v1.chat.resolver", ProviderResolver())
+    return built
+
+
+@pytest.mark.asyncio
+async def test_legacy_path_without_model_defaults_uses_first_enabled_provider(
+    client, db_session, monkeypatch
+):
+    await _create_provider(client, name="Legacy Only")
+    built = _patch_network_with_default(monkeypatch, {}, default="legacy reply")
+
+    resp = await _chat(client)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["type"] == "message"
+    assert resp.json()["data"]["content"] == "legacy reply"
+    assert len(built) == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_path_without_enabled_provider_returns_400(client, db_session, monkeypatch):
+    await _create_provider(client, name="Disabled Only", enabled=False)
+    _patch_network_with_default(monkeypatch, {}, default="unused")
+
+    resp = await _chat(client)
+
+    assert resp.status_code == 400
+    assert "没有可用的模型 provider" in resp.json()["detail"]
+
+
+# ── failover path: candidates configured ────────────────────────────────────
+@pytest.mark.asyncio
+async def test_retryable_primary_failure_fails_over_to_secondary(
+    client, db_session, monkeypatch
+):
+    primary = await _create_provider(client, name="Primary")
+    secondary = await _create_provider(client, name="Secondary")
+    await _register_model(client, primary, "model-a")
+    await _register_model(client, secondary, "model-b")
+    await _put_chat_defaults(
+        client,
+        [
+            {"provider_id": primary, "model_id": "model-a"},
+            {"provider_id": secondary, "model_id": "model-b"},
+        ],
+    )
+    built = _patch_network(monkeypatch, {primary: _connection_error(), secondary: "reply from b"})
+
+    resp = await _chat(client)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["content"] == "reply from b"
+    assert built == [primary, secondary]  # tried in candidate order
+
+
+@pytest.mark.asyncio
+async def test_business_error_does_not_fail_over(client, db_session, monkeypatch):
+    primary = await _create_provider(client, name="Primary")
+    secondary = await _create_provider(client, name="Secondary")
+    await _register_model(client, primary, "model-a")
+    await _register_model(client, secondary, "model-b")
+    await _put_chat_defaults(
+        client,
+        [
+            {"provider_id": primary, "model_id": "model-a"},
+            {"provider_id": secondary, "model_id": "model-b"},
+        ],
+    )
+    built = _patch_network(monkeypatch, {primary: _auth_error(), secondary: "unused"})
+
+    resp = await _chat(client)
+
+    # 4xx = configuration problem → re-raised immediately (decision #7), no failover
+    assert resp.status_code == 502
+    assert "模型调用失败" in resp.json()["detail"]
+    assert built == [primary]  # secondary never built
+
+
+@pytest.mark.asyncio
+async def test_all_candidates_unavailable_returns_502(client, db_session, monkeypatch):
+    primary = await _create_provider(client, name="Primary")
+    secondary = await _create_provider(client, name="Secondary")
+    await _register_model(client, primary, "model-a")
+    await _register_model(client, secondary, "model-b")
+    await _put_chat_defaults(
+        client,
+        [
+            {"provider_id": primary, "model_id": "model-a"},
+            {"provider_id": secondary, "model_id": "model-b"},
+        ],
+    )
+    built = _patch_network(
+        monkeypatch, {primary: _connection_error(), secondary: _connection_error()}
+    )
+
+    resp = await _chat(client)
+
+    assert resp.status_code == 502
+    assert "no live provider candidate" in resp.json()["detail"]
+    assert built == [primary, secondary]
+
+
+@pytest.mark.asyncio
+async def test_disabled_candidate_is_skipped(client, db_session, monkeypatch):
+    primary = await _create_provider(client, name="Primary Disabled", enabled=False)
+    secondary = await _create_provider(client, name="Secondary")
+    await _register_model(client, primary, "model-a")
+    await _register_model(client, secondary, "model-b")
+    await _put_chat_defaults(
+        client,
+        [
+            {"provider_id": primary, "model_id": "model-a"},
+            {"provider_id": secondary, "model_id": "model-b"},
+        ],
+    )
+    built = _patch_network(monkeypatch, {secondary: "reply from b"})
+
+    resp = await _chat(client)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["content"] == "reply from b"
+    assert built == [secondary]  # disabled primary never built
+
+
+@pytest.mark.asyncio
+async def test_explicit_provider_id_bypasses_failover(client, db_session, monkeypatch):
+    primary = await _create_provider(client, name="Primary")
+    secondary = await _create_provider(client, name="Secondary")
+    await _register_model(client, primary, "model-a")
+    await _register_model(client, secondary, "model-b")
+    await _put_chat_defaults(
+        client,
+        [
+            {"provider_id": primary, "model_id": "model-a"},
+            {"provider_id": secondary, "model_id": "model-b"},
+        ],
+    )
+    built = _patch_network(monkeypatch, {primary: "explicit reply", secondary: "unused"})
+
+    resp = await client.post(
+        "/api/v1/chat",
+        json={
+            "provider_id": primary,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["content"] == "explicit reply"
+    assert built == [primary]

--- a/tests/unit/llm/test_resolver.py
+++ b/tests/unit/llm/test_resolver.py
@@ -111,6 +111,34 @@ async def test_resolve_returns_none_when_candidates_empty(db_session: AsyncSessi
     assert await resolver.resolve(db_session, "executor") is None
 
 
+@pytest.mark.asyncio
+async def test_resolve_returns_none_when_primary_provider_disabled(db_session: AsyncSession):
+    provider_a = await _make_provider(db_session, "provider-a")
+    provider_a.enabled = False
+    await db_session.commit()
+    await _make_default(
+        db_session,
+        "chat",
+        [{"provider_id": provider_a.id, "model_id": "model-a"}],
+    )
+    resolver = ProviderResolver(now=FakeClock())
+    assert await resolver.resolve(db_session, "chat") is None
+
+
+@pytest.mark.asyncio
+async def test_has_candidates_true_only_for_nonempty_role(db_session: AsyncSession):
+    resolver = ProviderResolver(now=FakeClock())
+    assert await resolver.has_candidates(db_session, "chat") is False
+    await _make_default(
+        db_session,
+        "chat",
+        [{"provider_id": "any-provider-id", "model_id": "model-a"}],
+    )
+    assert await resolver.has_candidates(db_session, "chat") is True
+    await _make_default(db_session, "executor", [])
+    assert await resolver.has_candidates(db_session, "executor") is False
+
+
 # ---------------------------------------------------------------------------
 # resolve_with_fallback() — sequential failover
 # ---------------------------------------------------------------------------
@@ -155,6 +183,65 @@ async def test_no_default_raises_resolver_error(db_session: AsyncSession):
     resolver = ProviderResolver(now=FakeClock())
     operation = AsyncMock()
     with pytest.raises(ResolverError):
+        await resolver.resolve_with_fallback(db_session, "chat", operation)
+    operation.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_disabled_provider_skipped_without_cooldown_uses_next(
+    db_session: AsyncSession,
+):
+    provider_a = await _make_provider(db_session, "provider-a")
+    provider_b = await _make_provider(db_session, "provider-b")
+    provider_a.enabled = False
+    await db_session.commit()
+    await _make_default(
+        db_session,
+        "chat",
+        [
+            {"provider_id": provider_a.id, "model_id": "model-a"},
+            {"provider_id": provider_b.id, "model_id": "model-b"},
+        ],
+    )
+
+    resolver = ProviderResolver(now=FakeClock())
+    operation = AsyncMock(side_effect=["b-result"])
+
+    patched_adapter = patch(
+        "backend.llm.resolver.get_adapter", side_effect=lambda p: object()
+    )
+    with patched_adapter as mock_get_adapter:
+        result = await resolver.resolve_with_fallback(db_session, "chat", operation)
+
+    assert result == "b-result"
+    # the disabled candidate never reached adapter construction or the operation
+    operation.assert_called_once()
+    assert operation.call_args.args[1] == "model-b"
+    assert mock_get_adapter.call_count == 1
+    # disabling is an operator choice, not a liveness failure → no cooldown
+    assert resolver._is_cooled(provider_a.id) is False
+    assert resolver._is_cooled(provider_b.id) is False
+
+
+@pytest.mark.asyncio
+async def test_all_candidates_disabled_raises_resolver_error(db_session: AsyncSession):
+    provider_a = await _make_provider(db_session, "provider-a")
+    provider_b = await _make_provider(db_session, "provider-b")
+    provider_a.enabled = False
+    provider_b.enabled = False
+    await db_session.commit()
+    await _make_default(
+        db_session,
+        "chat",
+        [
+            {"provider_id": provider_a.id, "model_id": "model-a"},
+            {"provider_id": provider_b.id, "model_id": "model-b"},
+        ],
+    )
+
+    resolver = ProviderResolver(now=FakeClock())
+    operation = AsyncMock()
+    with pytest.raises(ResolverError, match="tried=0"):
         await resolver.resolve_with_fallback(db_session, "chat", operation)
     operation.assert_not_called()
 
@@ -314,10 +401,15 @@ async def test_concurrent_resolve_with_fallback_is_consistent(db_engine):
 
     async def run_one():
         async with session_factory() as session:
-            with patch("backend.llm.resolver.get_adapter", side_effect=lambda p: object()):
-                return await resolver.resolve_with_fallback(session, "chat", operation)
+            return await resolver.resolve_with_fallback(session, "chat", operation)
 
-    results = await asyncio.gather(*(run_one() for _ in range(20)))
+    # The get_adapter patch must wrap the whole gather, NOT each task: a
+    # `with patch(...)` entered per-task around an `await` makes the
+    # enter/exit attribute-restore race under concurrent scheduling and can
+    # leak the mock onto the module attribute after the test (breaking any
+    # later test that resolves a real adapter).
+    with patch("backend.llm.resolver.get_adapter", side_effect=lambda p: object()):
+        results = await asyncio.gather(*(run_one() for _ in range(20)))
 
     assert results == ["result-model-b"] * 20
     assert resolver._is_cooled(provider_a.id) is True


### PR DESCRIPTION
Closes #55 — 选择「接入路径」：把 `chat` role 接入 `ProviderResolver.resolve_with_fallback()`。

## 做了什么
- **chat 端点**：当 `model_defaults.candidates` 为 `chat` role 配置了候选时，走 `resolve_with_fallback()` —— 连接级失败（connect error/timeout/5xx，decision #7）按顺序故障转移到下一候选；业务级失败（4xx）立即重抛不转移。显式 `provider_id` 与无候选 role 保持原有单 provider 行为（兼容既有安装）。
- **工具循环（JSON + XML）**：LLM 调用失败改为抛 `LlmAdapterError`（`classify_retryable` 区分），由 resolver 决定是否转移；502 转换收敛在端点边界。
- **resolver**：`resolve()`/`resolve_with_fallback()` 跳过 `enabled=False` 的 provider（治理选择，非活性故障，不进 cooldown）；新增公开 `has_candidates()` 供 legacy 回退分支使用。
- **测试**：resolver 单测（disabled-skip、has_candidates）+ 新增 `tests/integration/test_chat_failover_api.py`，通过真实 `POST /api/v1/chat` 链路验证：legacy 路径、可重试故障转移、4xx 不转移、全部不可用 502、disabled 跳过、显式 provider 绕过。
- 顺带修复 `test_resolver.py` 并发测试的 patch 泄漏（`asyncio.gather` 内逐任务 `unittest.mock.patch` 围绕 `await` 导致属性还原竞争，把 mock 泄漏到后续测试）。

## 验证证据
- 全量后端测试：**2692 passed / 0 failed**（含新增 11 个测试；本机需 `pip install socksio` 消除环境性 flaky，见下）。
- `mypy` 变更文件通过；`ruff` 无新增错误（仅存量 E501/UP045）。
- 真实后端 API 验收（fresh sqlite + 本地 fake OpenAI 服务器）：provider 创建/编辑/删除、`POST /{id}/test` 连接测试 ok:true、模型 sync 发现 2 个模型、`PUT/GET /model-defaults` 默认顺序持久化、chat 错误反馈（SSRF guard 502、无 provider 400、非法 role/未注册 model 400）。

## 遗留（需人工）
- **模型供应商 UI 的真机验收**（创建/编辑/删除/同步/连接测试/默认顺序/错误提示的浏览器走查）——需要真实后端 + 浏览器，本轮以 API 级验收替代。
- 环境性发现：本机 host 有 Clash 代理（`127.0.0.1:7897`），沙箱偶发注入 `ALL_PROXY=socks5://...`，httpx 0.28.1 在 `AsyncClient()` 构造时急切构建 SOCKS transport → 无 `socksio` 时抛 ImportError，导致一批真实 HTTP 测试偶发失败（与本次改动无关，`tests/integration` 单独跑不包含本 PR 文件时同样复现 17 个）。建议 dev 依赖补 `httpx[socks]`。