### PR TITLE
feat(notifications): expose delivery and ACK evidence

### DIFF
--- a/frontend/app/(app)/notifications/page.tsx
+++ b/frontend/app/(app)/notifications/page.tsx
@@ -1,12 +1,26 @@
 'use client'
 
-import { useState } from 'react'
-import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { Fragment, useMemo, useState } from 'react'
+import { Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 
-import { useDeleteNotificationRule, useNotificationRules } from '@/lib/api/hooks'
-import type { NotificationRule } from '@/lib/api/types'
+import {
+  useDeleteNotificationRule,
+  useInfiniteNotificationLogs,
+  useInfiniteNotificationRules,
+  useNotificationRulesByIds,
+} from '@/lib/api/hooks'
+import type { NotificationLog, NotificationRule } from '@/lib/api/types'
+import { formatDateTime, formatRelative } from '@/lib/format'
 import { notificationChannelLabel } from '@/lib/notification-channels'
+import {
+  acknowledgementStatusPresentation,
+  dedupeDeliveryAttempts,
+  sanitizedDeliveryErrorSummary,
+  transportStatusPresentation,
+  type DeliveryStatusPresentation,
+} from '@/lib/notifications/delivery-status'
+import { cn } from '@/lib/utils'
 import { NotificationRuleFormDialog } from '@/components/notifications/notification-rule-form-dialog'
 import { BACKEND_HINT, EmptyState, ErrorState, LoadingState } from '@/components/shell/data-states'
 import { PageContainer } from '@/components/shell/page-container'
@@ -14,7 +28,15 @@ import { ACTION_CENTER_TABS, RouteTabs } from '@/components/shell/route-tabs'
 import { StatusBadge } from '@/components/shell/status-badge'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 import {
   Table,
   TableBody,
@@ -24,9 +46,30 @@ import {
   TableRow,
 } from '@/components/ui/table'
 
-export default function NotificationsPage() {
-  const { data, isLoading, isError, error } = useNotificationRules()
-  const rules = data?.data ?? []
+const DELIVERY_PAGE_SIZE = 25
+const RULE_PAGE_SIZE = 50
+
+function DeliveryStatusBadge({ presentation }: { presentation: DeliveryStatusPresentation }) {
+  return (
+    <Badge
+      variant={presentation.tone === 'negative' ? 'destructive' : 'outline'}
+      className={cn(
+        presentation.tone === 'positive' &&
+          'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+        presentation.tone === 'warning' &&
+          'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+        presentation.tone === 'informative' &&
+          'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300',
+        presentation.tone === 'neutral' && 'text-muted-foreground',
+      )}
+      title={presentation.description}
+    >
+      {presentation.label}
+    </Badge>
+  )
+}
+
+function RuleTable({ rules }: { rules: NotificationRule[] }) {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
   const deleteMutation = useDeleteNotificationRule()
 
@@ -45,10 +88,180 @@ export default function NotificationsPage() {
   }
 
   return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>名称</TableHead>
+          <TableHead>触发事件</TableHead>
+          <TableHead>通知方式</TableHead>
+          <TableHead>状态</TableHead>
+          <TableHead className="text-right">操作</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rules.map((rule) => (
+          <Fragment key={rule.id}>
+            <TableRow>
+              <TableCell className="font-medium">{rule.name}</TableCell>
+              <TableCell>
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                  {rule.trigger_event}
+                </code>
+              </TableCell>
+              <TableCell>
+                <Badge variant="secondary">{notificationChannelLabel(rule.notifier_type)}</Badge>
+              </TableCell>
+              <TableCell>
+                <StatusBadge status={rule.enabled ? 'enabled' : 'disabled'} />
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center justify-end gap-1">
+                  <NotificationRuleFormDialog
+                    mode="edit"
+                    rule={rule}
+                    triggerLabel=""
+                    triggerIcon={<Pencil className="size-3.5" />}
+                    triggerVariant="ghost"
+                    triggerSize="icon-sm"
+                    triggerAriaLabel="编辑规则"
+                  />
+                  <Button
+                    variant={confirmDeleteId === rule.id ? 'destructive' : 'ghost'}
+                    size="icon-sm"
+                    aria-label={confirmDeleteId === rule.id ? '确认删除并清除投递证据' : '删除规则'}
+                    disabled={deleteMutation.isPending}
+                    onClick={() => handleDelete(rule)}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </div>
+              </TableCell>
+            </TableRow>
+            {confirmDeleteId === rule.id ? (
+              <TableRow className="bg-destructive/5">
+                <TableCell colSpan={5}>
+                  <p className="text-sm text-destructive" role="alert">
+                    再次点击删除将永久删除该规则及其全部投递证据，此操作不可恢复。
+                  </p>
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </Fragment>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function DeliveryEvidenceTable({
+  logs,
+  rulesById,
+}: {
+  logs: NotificationLog[]
+  rulesById: Map<string, NotificationRule>
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>通知规则</TableHead>
+          <TableHead>技术提交</TableHead>
+          <TableHead>业务回执</TableHead>
+          <TableHead>关联记录</TableHead>
+          <TableHead>发生时间</TableHead>
+          <TableHead className="max-w-64">错误摘要</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {logs.map((log) => {
+          const rule = rulesById.get(log.rule_id)
+          const errorSummary =
+            sanitizedDeliveryErrorSummary(log.error_message) ||
+            (log.ack_status === 'failed' ? '业务回执失败' : null)
+          return (
+            <TableRow key={log.id}>
+              <TableCell>
+                <div className="font-medium">{rule?.name ?? `规则 ${log.rule_id.slice(0, 8)}`}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {rule ? notificationChannelLabel(rule.notifier_type) : log.rule_id.slice(0, 8)}
+                </div>
+              </TableCell>
+              <TableCell>
+                <DeliveryStatusBadge presentation={transportStatusPresentation(log.status)} />
+              </TableCell>
+              <TableCell>
+                <div className="flex flex-col items-start gap-1">
+                  <DeliveryStatusBadge
+                    presentation={acknowledgementStatusPresentation(log.ack_status, log.status)}
+                  />
+                  {log.acked_at ? (
+                    <span
+                      className="text-xs text-muted-foreground"
+                      title={formatDateTime(log.acked_at)}
+                    >
+                      {formatRelative(log.acked_at)}
+                    </span>
+                  ) : null}
+                </div>
+              </TableCell>
+              <TableCell>
+                {log.record_id ? (
+                  <code className="font-mono text-xs" title={log.record_id}>
+                    {log.record_id.slice(0, 8)}
+                  </code>
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </TableCell>
+              <TableCell className="text-muted-foreground" title={formatDateTime(log.created_at)}>
+                {formatRelative(log.created_at)}
+              </TableCell>
+              <TableCell className="max-w-64">
+                {errorSummary ? (
+                  <span className="line-clamp-2 text-sm text-destructive" title={errorSummary}>
+                    {errorSummary}
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}
+
+export default function NotificationsPage() {
+  const rulesQuery = useInfiniteNotificationRules({ limit: RULE_PAGE_SIZE })
+  const logsQuery = useInfiniteNotificationLogs({ limit: DELIVERY_PAGE_SIZE })
+  const rules = useMemo(
+    () => dedupeDeliveryAttempts(rulesQuery.data?.pages.flatMap((page) => page.data) ?? []),
+    [rulesQuery.data],
+  )
+  const logs = useMemo(
+    () => dedupeDeliveryAttempts(logsQuery.data?.pages.flatMap((page) => page.data) ?? []),
+    [logsQuery.data],
+  )
+  const loadedRulesById = useMemo(() => new Map(rules.map((rule) => [rule.id, rule])), [rules])
+  const missingRuleIds = useMemo(
+    () => [...new Set(logs.map((log) => log.rule_id))].filter((id) => !loadedRulesById.has(id)),
+    [loadedRulesById, logs],
+  )
+  const ruleLookups = useNotificationRulesByIds(missingRuleIds)
+  const rulesById = new Map(loadedRulesById)
+  ruleLookups.forEach((query) => {
+    if (query.data) rulesById.set(query.data.id, query.data)
+  })
+  const totalRules = Math.max(rulesQuery.data?.pages[0]?.meta?.total ?? 0, rules.length)
+  const totalLogs = Math.max(logsQuery.data?.pages[0]?.meta?.total ?? 0, logs.length)
+
+  return (
     <PageContainer
       eyebrow="Delivery rules"
       title="任务与通知"
-      description="管理采集事件触发的通知规则；投递失败会汇入待处理视图。"
+      description="管理通知规则，并核对从通道提交到业务回执的完整投递证据。"
       tabs={<RouteTabs tabs={ACTION_CENTER_TABS} />}
       actions={
         <NotificationRuleFormDialog
@@ -58,69 +271,154 @@ export default function NotificationsPage() {
         />
       }
     >
-      {isLoading ? (
-        <LoadingState />
-      ) : isError ? (
-        <ErrorState message={(error as Error)?.message} hint={BACKEND_HINT} />
-      ) : rules.length === 0 ? (
-        <EmptyState title="暂无通知规则" description="创建规则以在采集事件发生时收到通知。" />
-      ) : (
-        <Card className="overflow-hidden py-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>名称</TableHead>
-                <TableHead>触发事件</TableHead>
-                <TableHead>通知方式</TableHead>
-                <TableHead>状态</TableHead>
-                <TableHead className="text-right">操作</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rules.map((r) => (
-                <TableRow key={r.id}>
-                  <TableCell className="font-medium">{r.name}</TableCell>
-                  <TableCell>
-                    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
-                      {r.trigger_event}
-                    </code>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="secondary">
-                      {notificationChannelLabel(r.notifier_type)}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <StatusBadge status={r.enabled ? 'enabled' : 'disabled'} />
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center justify-end gap-1">
-                      <NotificationRuleFormDialog
-                        mode="edit"
-                        rule={r}
-                        triggerLabel=""
-                        triggerIcon={<Pencil className="size-3.5" />}
-                        triggerVariant="ghost"
-                        triggerSize="icon-sm"
-                        triggerAriaLabel="编辑规则"
-                      />
-                      <Button
-                        variant={confirmDeleteId === r.id ? 'destructive' : 'ghost'}
-                        size="icon-sm"
-                        aria-label={confirmDeleteId === r.id ? '确认删除' : '删除规则'}
-                        disabled={deleteMutation.isPending}
-                        onClick={() => handleDelete(r)}
-                      >
-                        <Trash2 className="size-3.5" />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+      <section aria-labelledby="notification-rules-title" className="space-y-3">
+        <div>
+          <h2 id="notification-rules-title" className="text-lg font-semibold">
+            通知规则
+          </h2>
+          <p className="text-sm text-muted-foreground">配置采集事件触发的通知方式。</p>
+        </div>
+        {rulesQuery.isLoading && rules.length === 0 ? (
+          <LoadingState />
+        ) : rulesQuery.isError && rules.length === 0 ? (
+          <ErrorState
+            message={(rulesQuery.error as Error)?.message}
+            hint={BACKEND_HINT}
+            action={
+              <Button variant="outline" onClick={() => rulesQuery.refetch()}>
+                重试
+              </Button>
+            }
+          />
+        ) : rules.length === 0 ? (
+          <EmptyState title="暂无通知规则" description="创建规则以在采集事件发生时收到通知。" />
+        ) : (
+          <Card className="overflow-hidden py-0">
+            <div className="overflow-x-auto">
+              <RuleTable rules={rules} />
+            </div>
+            <CardFooter className="flex-col items-stretch gap-3">
+              {rulesQuery.isError ? (
+                <div
+                  className="flex flex-wrap items-center justify-between gap-2 text-sm text-destructive"
+                  role="alert"
+                >
+                  <span>更新规则列表失败，已加载的规则仍保留。</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      rulesQuery.isFetchNextPageError
+                        ? rulesQuery.fetchNextPage()
+                        : rulesQuery.refetch()
+                    }
+                  >
+                    重试
+                  </Button>
+                </div>
+              ) : null}
+              <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+                <span>已显示 {rules.length} / {totalRules} 条规则</span>
+                {rulesQuery.hasNextPage ? (
+                  <Button
+                    variant="outline"
+                    onClick={() => rulesQuery.fetchNextPage()}
+                    disabled={rulesQuery.isFetchingNextPage}
+                  >
+                    {rulesQuery.isFetchingNextPage ? '正在加载…' : '加载更多规则'}
+                  </Button>
+                ) : null}
+              </div>
+            </CardFooter>
+          </Card>
+        )}
+      </section>
+
+      <section aria-labelledby="delivery-evidence-title">
+        <Card>
+          <CardHeader className="border-b">
+            <div>
+              <CardTitle id="delivery-evidence-title">投递证据</CardTitle>
+              <CardDescription className="mt-1">
+                技术提交与业务回执分开显示；仅展示脱敏状态、关联标识和错误摘要。
+              </CardDescription>
+            </div>
+            <CardAction>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => logsQuery.refetch()}
+                disabled={logsQuery.isFetching}
+                aria-label="刷新投递证据"
+              >
+                <RefreshCw className={cn('size-4', logsQuery.isFetching && 'animate-spin')} />
+                刷新
+              </Button>
+            </CardAction>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {logsQuery.isLoading && logs.length === 0 ? (
+              <LoadingState rows={3} />
+            ) : logsQuery.isError && logs.length === 0 ? (
+              <ErrorState
+                message={(logsQuery.error as Error)?.message}
+                hint="通知规则仍可继续管理；恢复连接后可单独重试投递证据。"
+                action={
+                  <Button variant="outline" onClick={() => logsQuery.refetch()}>
+                    重试
+                  </Button>
+                }
+              />
+            ) : logs.length === 0 ? (
+              <EmptyState
+                title="暂无投递证据"
+                description="通知规则触发后，这里会显示提交和回执状态。"
+              />
+            ) : (
+              <>
+                {logsQuery.isError ? (
+                  <div
+                    className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive"
+                    role="alert"
+                  >
+                    <span>更新投递证据失败，已加载的记录仍保留。</span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        logsQuery.isFetchNextPageError
+                          ? logsQuery.fetchNextPage()
+                          : logsQuery.refetch()
+                      }
+                    >
+                      重试
+                    </Button>
+                  </div>
+                ) : null}
+                <div className="overflow-x-auto rounded-lg border">
+                  <DeliveryEvidenceTable logs={logs} rulesById={rulesById} />
+                </div>
+                <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+                  <span>已显示 {logs.length} / {totalLogs} 条</span>
+                  {logsQuery.hasNextPage ? (
+                    <Button
+                      variant="outline"
+                      onClick={() => logsQuery.fetchNextPage()}
+                      disabled={logsQuery.isFetchingNextPage}
+                    >
+                      {logsQuery.isFetchingNextPage
+                        ? '正在加载…'
+                        : logsQuery.isFetchNextPageError
+                          ? '重试加载更多'
+                          : '加载更多'}
+                    </Button>
+                  ) : null}
+                </div>
+              </>
+            )}
+          </CardContent>
         </Card>
-      )}
+      </section>
     </PageContainer>
   )
 }

--- a/frontend/lib/api/endpoints.ts
+++ b/frontend/lib/api/endpoints.ts
@@ -536,8 +536,15 @@ export const deleteSchedule = (id: string) =>
   apiClient.delete<ApiResponse<null>>(`/schedules/${id}`).then((r) => r.data)
 
 // ── Notifications ──────────────────────────────────────────────────────────────
-export const listNotificationRules = () =>
-  apiClient.get<ApiResponse<NotificationRule[]>>('/notifications/rules').then((r) => r.data)
+export const listNotificationRules = (params?: { page?: number; limit?: number }) =>
+  apiClient
+    .get<ApiResponse<NotificationRule[]>>('/notifications/rules', { params })
+    .then((r) => r.data)
+
+export const getNotificationRule = (id: string) =>
+  apiClient
+    .get<ApiResponse<NotificationRule>>(`/notifications/rules/${id}`)
+    .then((r) => r.data.data)
 
 export const createNotificationRule = (data: NotificationRuleInput) =>
   apiClient

--- a/frontend/lib/api/hooks.ts
+++ b/frontend/lib/api/hooks.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useInfiniteQuery, useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import * as api from './endpoints'
 import type {
@@ -763,6 +763,29 @@ export function useNotificationRules() {
   })
 }
 
+export function useInfiniteNotificationRules(params?: { limit?: number }) {
+  return useInfiniteQuery({
+    queryKey: ['notification-rules', 'infinite', params],
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) => api.listNotificationRules({ ...params, page: pageParam }),
+    getNextPageParam: (lastPage) => {
+      const meta = lastPage.meta
+      return meta && meta.page < meta.pages ? meta.page + 1 : undefined
+    },
+  })
+}
+
+export function useNotificationRulesByIds(ids: string[]) {
+  return useQueries({
+    queries: ids.map((id) => ({
+      queryKey: ['notification-rules', id],
+      queryFn: () => api.getNotificationRule(id),
+      staleTime: 30_000,
+      retry: false,
+    })),
+  })
+}
+
 export function useCreateNotificationRule() {
   const queryClient = useQueryClient()
   return useMutation({
@@ -784,7 +807,12 @@ export function useDeleteNotificationRule() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (id: string) => api.deleteNotificationRule(id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notification-rules'] }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['notification-rules'] }),
+        queryClient.invalidateQueries({ queryKey: ['notification-logs'] }),
+      ])
+    },
   })
 }
 

--- a/frontend/lib/notifications/delivery-status.ts
+++ b/frontend/lib/notifications/delivery-status.ts
@@ -1,0 +1,120 @@
+export type DeliveryStatusTone = 'informative' | 'positive' | 'warning' | 'negative' | 'neutral'
+
+export interface DeliveryStatusPresentation {
+  label: string
+  description: string
+  tone: DeliveryStatusTone
+}
+
+export function sanitizedDeliveryErrorSummary(error?: string | null): string | null {
+  if (!error) return null
+  const normalized = error.toLowerCase()
+  if (/timeout|timed out/.test(normalized)) return '通知通道连接超时'
+  if (/certificate|\btls\b|\bssl\b/.test(normalized)) return '通知通道安全校验失败'
+  if (/name resolution|dns|resolve host/.test(normalized)) return '无法解析通知通道地址'
+  if (/connect|connection/.test(normalized)) return '无法连接通知通道'
+  return '通知处理失败（详细错误已隐藏）'
+}
+
+export function dedupeDeliveryAttempts<T extends { id: string }>(items: readonly T[]): T[] {
+  const seen = new Set<string>()
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false
+    seen.add(item.id)
+    return true
+  })
+}
+
+export function transportStatusPresentation(status: string): DeliveryStatusPresentation {
+  switch (status.toLowerCase()) {
+    case 'sent':
+    case 'success':
+    case 'completed':
+      return {
+        label: '已提交',
+        description: '通知请求已被通道接受，不代表业务方已确认。',
+        tone: 'informative',
+      }
+    case 'pending':
+    case 'queued':
+      return {
+        label: '等待提交',
+        description: '通知请求仍在等待通道处理。',
+        tone: 'warning',
+      }
+    case 'failed':
+    case 'error':
+      return {
+        label: '提交失败',
+        description: '通知请求未成功提交到通道。',
+        tone: 'negative',
+      }
+    default:
+      return {
+        label: '状态未知',
+        description: '后端返回了当前控制台无法识别的提交状态。',
+        tone: 'neutral',
+      }
+  }
+}
+
+export function acknowledgementStatusPresentation(
+  status: string,
+  transportStatus?: string,
+): DeliveryStatusPresentation {
+  const normalizedStatus = status.toLowerCase()
+  const normalizedTransport = transportStatus?.toLowerCase()
+  if (
+    normalizedStatus === 'not_required' &&
+    (normalizedTransport === 'pending' || normalizedTransport === 'queued')
+  ) {
+    return {
+      label: '待提交后确定',
+      description: '通知尚未提交，回执要求和状态将在提交后确定。',
+      tone: 'neutral',
+    }
+  }
+  if (
+    normalizedStatus === 'not_required' &&
+    (normalizedTransport === 'failed' || normalizedTransport === 'error')
+  ) {
+    return {
+      label: '未进入回执',
+      description: '通知提交失败，因此没有进入业务回执阶段。',
+      tone: 'neutral',
+    }
+  }
+
+  switch (normalizedStatus) {
+    case 'acked':
+      return {
+        label: '已确认',
+        description: '业务方已返回有效确认。',
+        tone: 'positive',
+      }
+    case 'pending':
+      return {
+        label: '等待回执',
+        description: '通知已提交，仍在等待业务方确认。',
+        tone: 'warning',
+      }
+    case 'failed':
+      return {
+        label: '回执失败',
+        description: '业务方回执未通过验证或明确失败。',
+        tone: 'negative',
+      }
+    case 'not_required':
+      return {
+        label: '无需回执',
+        description: '该通知通道未配置业务回执。',
+        tone: 'neutral',
+      }
+    default:
+      return {
+        label: '状态未知',
+        description: '后端返回了当前控制台无法识别的回执状态。',
+        tone: 'neutral',
+      }
+  }
+}

--- a/frontend/scripts/check-notification-evidence-regressions.mjs
+++ b/frontend/scripts/check-notification-evidence-regressions.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const page = fs.readFileSync(path.join(root, 'app/(app)/notifications/page.tsx'), 'utf8')
+const hooks = fs.readFileSync(path.join(root, 'lib/api/hooks.ts'), 'utf8')
+const endpoints = fs.readFileSync(path.join(root, 'lib/api/endpoints.ts'), 'utf8')
+
+test('notification center loads paginated delivery evidence', () => {
+  assert.match(page, /useInfiniteNotificationLogs\(\{ limit: DELIVERY_PAGE_SIZE \}\)/)
+  assert.match(page, /fetchNextPage\(\)/)
+  assert.match(page, /已显示 \{logs\.length\} \/ \{totalLogs\} 条/)
+})
+
+test('rules and evidence expose independent recovery paths', () => {
+  assert.match(page, /rulesQuery\.isError/)
+  assert.match(page, /logsQuery\.isError/)
+  assert.match(page, /logsQuery\.isError && logs\.length === 0/)
+  assert.match(page, /更新投递证据失败，已加载的记录仍保留/)
+  assert.match(page, /logsQuery\.refetch\(\)/)
+})
+
+test('rule management paginates and missing log rules resolve by exact id', () => {
+  assert.match(page, /useInfiniteNotificationRules\(\{ limit: RULE_PAGE_SIZE \}\)/)
+  assert.match(page, /useNotificationRulesByIds\(missingRuleIds\)/)
+  assert.match(hooks, /api\.getNotificationRule\(id\)/)
+  assert.match(endpoints, /`\/notifications\/rules\/\$\{id\}`/)
+  assert.doesNotMatch(page, /未知或已删除规则/)
+})
+
+test('offset pages are deduplicated and destructive evidence loss is disclosed', () => {
+  assert.match(page, /dedupeDeliveryAttempts\(logsQuery\.data/)
+  assert.match(page, /永久删除该规则及其全部投递证据，此操作不可恢复/)
+})
+
+test('delivery evidence does not render raw transport or ACK payloads', () => {
+  assert.doesNotMatch(page, /log\.response_data/)
+  assert.doesNotMatch(page, /log\.ack_data/)
+  assert.match(page, /sanitizedDeliveryErrorSummary\(log\.error_message\)/)
+})
+
+test('deleting a notification rule invalidates its cascaded log view', () => {
+  const deletionHook = hooks.slice(
+    hooks.indexOf('export function useDeleteNotificationRule'),
+    hooks.indexOf('export function useNotificationLogs'),
+  )
+  assert.match(deletionHook, /queryKey: \['notification-rules'\]/)
+  assert.match(deletionHook, /queryKey: \['notification-logs'\]/)
+})

--- a/frontend/scripts/notification-delivery-status.test.mjs
+++ b/frontend/scripts/notification-delivery-status.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  acknowledgementStatusPresentation,
+  dedupeDeliveryAttempts,
+  sanitizedDeliveryErrorSummary,
+  transportStatusPresentation,
+} from '../lib/notifications/delivery-status.ts'
+
+test('a successful transport is submitted, never presented as confirmed delivery', () => {
+  const status = transportStatusPresentation('sent')
+
+  assert.equal(status.label, '已提交')
+  assert.doesNotMatch(status.label, /送达|确认/)
+  assert.match(status.description, /不代表业务方已确认/)
+})
+
+test('transport failures remain operationally distinct from ACK failures', () => {
+  assert.deepEqual(transportStatusPresentation('failed'), {
+    label: '提交失败',
+    description: '通知请求未成功提交到通道。',
+    tone: 'negative',
+  })
+  assert.deepEqual(acknowledgementStatusPresentation('failed'), {
+    label: '回执失败',
+    description: '业务方回执未通过验证或明确失败。',
+    tone: 'negative',
+  })
+})
+
+test('all backend ACK states have explicit product semantics', () => {
+  assert.equal(acknowledgementStatusPresentation('acked', 'sent').label, '已确认')
+  assert.equal(acknowledgementStatusPresentation('pending', 'sent').label, '等待回执')
+  assert.equal(acknowledgementStatusPresentation('not_required', 'sent').label, '无需回执')
+})
+
+test('provisional ACK defaults are not mistaken for final no-ACK semantics', () => {
+  assert.equal(
+    acknowledgementStatusPresentation('not_required', 'pending').label,
+    '待提交后确定',
+  )
+  assert.equal(
+    acknowledgementStatusPresentation('not_required', 'failed').label,
+    '未进入回执',
+  )
+})
+
+test('a real downstream ACK outranks a transport-side failure inference', () => {
+  assert.equal(acknowledgementStatusPresentation('acked', 'failed').label, '已确认')
+  assert.equal(acknowledgementStatusPresentation('failed', 'failed').label, '回执失败')
+  assert.equal(acknowledgementStatusPresentation('pending', 'failed').label, '等待回执')
+})
+
+test('unknown backend values fail closed to an unknown state', () => {
+  assert.equal(transportStatusPresentation('unexpected').label, '状态未知')
+  assert.equal(acknowledgementStatusPresentation('unexpected').label, '状态未知')
+})
+
+test('error summaries use an allow-list and never repeat secret-shaped input', () => {
+  assert.equal(
+    sanitizedDeliveryErrorSummary(
+      'Authorization: Bearer sk-live-secret; password=hunter2; Cookie=session-secret',
+    ),
+    '通知处理失败（详细错误已隐藏）',
+  )
+  assert.equal(sanitizedDeliveryErrorSummary('ConnectTimeout: POST https://secret.example'), '通知通道连接超时')
+  assert.equal(sanitizedDeliveryErrorSummary(null), null)
+})
+
+test('offset pagination duplicates are removed by stable delivery id', () => {
+  assert.deepEqual(
+    dedupeDeliveryAttempts([
+      { id: 'new', page: 1 },
+      { id: 'boundary', page: 1 },
+      { id: 'boundary', page: 2 },
+      { id: 'old', page: 2 },
+    ]),
+    [
+      { id: 'new', page: 1 },
+      { id: 'boundary', page: 1 },
+      { id: 'old', page: 2 },
+    ],
+  )
+})


### PR DESCRIPTION
Closes #84

## Product outcome

- Adds a dedicated delivery-evidence section to the notification center.
- Separates technical channel submission from downstream business ACK semantics.
- Shows rule, transport state, ACK state, record id, time, and an allow-listed safe error summary without rendering raw response or ACK payloads.
- Keeps rule management usable when log loading fails, and preserves already-loaded rows when refresh or load-more requests fail.

## Operability and data integrity

- Adds pagination for both rules and delivery attempts, exact rule lookup for log rows outside loaded rule pages, and stable-id deduplication for offset pagination overlap.
- Refreshes both rule and log caches after cascaded rule deletion.
- Warns before rule deletion that all associated delivery evidence is permanently removed.
- Treats provisional `not_required` ACK values according to transport state while allowing a real downstream ACK to override a transport-side timeout/failure inference.

## Verification

- `node --experimental-strip-types --test scripts/notification-delivery-status.test.mjs scripts/check-notification-evidence-regressions.mjs` — 14/14 passed
- `node node_modules/typescript/bin/tsc --noEmit` — passed
- targeted ESLint — 0 errors
- `node node_modules/next/dist/bin/next build` — passed, 42/42 pages generated
- `git diff --check` — passed
- independent verifier review — no findings after two review/fix cycles