### PR TITLE
fix: harden runtime and delivery dispatch

### DIFF
--- a/backend/agent_runtime_dispatch.py
+++ b/backend/agent_runtime_dispatch.py
@@ -208,11 +208,16 @@ async def invoke_runtime(
     if config_errors:
         raise HTTPException(status_code=400, detail="; ".join(config_errors))
     terminal_event: dict | None = None
-    try:
-        async for event in adapter.invoke(task):
+    async for event in adapter.invoke(task):
+        if not isinstance(event, dict):
+            raise HTTPException(status_code=502, detail="runtime produced an invalid event")
+        if terminal_event is not None:
+            raise HTTPException(
+                status_code=502,
+                detail="runtime produced events after its terminal event",
+            )
+        if event.get("type") in {"done", "error"}:
             terminal_event = event
-    except RuntimeInvocationError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
     if terminal_event is None:
         raise HTTPException(
             status_code=502,

--- a/backend/agent_server.py
+++ b/backend/agent_server.py
@@ -124,21 +124,36 @@ _RUNTIME_BUNDLE_MANIFEST = os.environ.get(
 )
 
 
-def _available_agent_runtimes() -> list[str]:
-    runtimes = list(available_runtimes())
+def _bundle_declared_runtimes() -> set[str]:
     try:
         with open(_RUNTIME_BUNDLE_MANIFEST, encoding="utf-8") as manifest_file:
             manifest = json.load(manifest_file)
-        declared = {
-            capability.get("runtime")
-            for capability in manifest.get("capabilities", [])
-            if isinstance(capability, dict)
-        }
-        if "script-host" in declared and "script-host" not in runtimes:
-            runtimes.append("script-host")
     except (OSError, ValueError, TypeError):
-        pass
+        return set()
+    if not isinstance(manifest, dict):
+        return set()
+    capabilities = manifest.get("capabilities", [])
+    if not isinstance(capabilities, list):
+        return set()
+    return {
+        capability.get("runtime")
+        for capability in capabilities
+        if isinstance(capability, dict) and isinstance(capability.get("runtime"), str)
+    }
+
+
+def _available_agent_runtimes() -> list[str]:
+    runtimes = list(available_runtimes())
+    declared = _bundle_declared_runtimes()
+    if "script-host" in declared and "script-host" not in runtimes:
+        runtimes.append("script-host")
     return runtimes
+
+
+_EDGE_RUNTIME_CONFIG_KEYS = frozenset(
+    {"binary", "args", "env", "cwd", "project_root", "provider_dir", "usage_file"}
+)
+
 
 
 _AGENT_LABEL = os.environ.get("AGENT_LABEL", socket.gethostname())
@@ -278,6 +293,7 @@ async def _register_with_center(advertise_url: str) -> None:
         "label": _AGENT_LABEL,
         "agent_protocol": "http",
         "runtimes": _available_agent_runtimes(),
+        "runtime_capabilities": available_runtime_capabilities(),
         "profile_kind": _BROWSER_PROFILE_KIND,
     }
     proxies = _build_proxies()
@@ -665,6 +681,17 @@ async def invoke_runtime_http(
         raise HTTPException(
             status_code=403,
             detail="Codex runtime is only available through controller WS dispatch",
+        )
+    if req.runtime not in _bundle_declared_runtimes():
+        raise HTTPException(
+            status_code=403,
+            detail=f"runtime {req.runtime!r} is not declared by the installed bundle",
+        )
+    unsafe_keys = sorted(_EDGE_RUNTIME_CONFIG_KEYS.intersection(req.config))
+    if unsafe_keys:
+        raise HTTPException(
+            status_code=400,
+            detail="edge runtime config cannot override: " + ", ".join(unsafe_keys),
         )
     return await invoke_runtime(str(uuid.uuid4()), req, cdp_endpoint=_DEFAULT_CDP)
 

--- a/backend/services/feishu_bitable_delivery.py
+++ b/backend/services/feishu_bitable_delivery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -13,6 +14,29 @@ from backend.database import commit_session, rollback_session
 from backend.models.delivery_connection import DeliveryAttempt
 
 FEISHU_API_HOST = "https://open.feishu.cn"
+_DELIVERY_ATTEMPT_LEASE = timedelta(minutes=5)
+
+
+def _pending_attempt_is_stale(attempt: DeliveryAttempt) -> bool:
+    updated_at = attempt.updated_at
+    if updated_at.tzinfo is None:
+        updated_at = updated_at.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - updated_at >= _DELIVERY_ATTEMPT_LEASE
+
+
+def _mark_attempt_pending(
+    attempt: DeliveryAttempt,
+    *,
+    workflow_run_id: str,
+    evidence_digest: str | None,
+    field_map: dict[str, str],
+) -> None:
+    attempt.workflow_run_id = workflow_run_id
+    attempt.evidence_digest = evidence_digest
+    attempt.field_map = field_map
+    attempt.status = "pending"
+    attempt.error_code = None
+    attempt.updated_at = datetime.now(timezone.utc)
 
 
 class FeishuDeliveryError(RuntimeError):
@@ -126,29 +150,26 @@ async def deliver_record_once(
         DeliveryAttempt.app_token == app_token,
         DeliveryAttempt.table_id == table_id,
         DeliveryAttempt.record_id == record_id,
-    )
+    ).with_for_update()
     existing = (await session.execute(query)).scalar_one_or_none()
     if existing and existing.status == "succeeded":
         if existing.evidence_digest != evidence_digest or existing.field_map != field_map:
             raise FeishuDeliveryError("idempotency_conflict")
         return existing
-    if existing and existing.status == "pending":
-        return existing
+    if existing and existing.status == "pending" and not _pending_attempt_is_stale(existing):
+        raise FeishuDeliveryError("delivery_in_progress")
     attempt = existing or DeliveryAttempt(
         connection_id=connection.id,
         app_token=app_token,
         table_id=table_id,
         record_id=record_id,
+    )
+    _mark_attempt_pending(
+        attempt,
         workflow_run_id=workflow_run_id,
         evidence_digest=evidence_digest,
         field_map=field_map,
-        status="pending",
     )
-    attempt.workflow_run_id = workflow_run_id
-    attempt.evidence_digest = evidence_digest
-    attempt.field_map = field_map
-    attempt.status = "pending"
-    attempt.error_code = None
     if existing is None:
         session.add(attempt)
     try:
@@ -157,9 +178,23 @@ async def deliver_record_once(
     except IntegrityError:
         await rollback_session(session)
         winner = (await session.execute(query)).scalar_one_or_none()
-        if winner is not None:
+        if winner is None:
+            raise
+        if winner.status == "succeeded":
+            if winner.evidence_digest != evidence_digest or winner.field_map != field_map:
+                raise FeishuDeliveryError("idempotency_conflict")
             return winner
-        raise
+        if winner.status == "pending" and not _pending_attempt_is_stale(winner):
+            raise FeishuDeliveryError("delivery_in_progress")
+        attempt = winner
+        _mark_attempt_pending(
+            attempt,
+            workflow_run_id=workflow_run_id,
+            evidence_digest=evidence_digest,
+            field_map=field_map,
+        )
+        await session.flush()
+        await commit_session(session)
     try:
         attempt.remote_record_id = await create_record(connection, app_token, table_id, fields)
         attempt.status = "succeeded"

--- a/backend/services/operations_agent_runtime_service.py
+++ b/backend/services/operations_agent_runtime_service.py
@@ -81,17 +81,6 @@ def cancel_operations_agent_run(run_id: str) -> None:
         task.cancel()
 
 
-def _runtime_permission_mode(runtime: str, profile_mode: str) -> str:
-    """Translate the governed profile vocabulary to a CLI vocabulary.
-
-    Permission profiles are product-level and intentionally shared by every
-    Agent runtime.  Codex uses ``read_only`` for the same contract that the
-    product calls ``observe_only``; passing the product value through verbatim
-    makes an otherwise healthy Codex node reject the task as invalid config.
-    """
-    if runtime == "codex" and profile_mode == "observe_only":
-        return "read_only"
-    return profile_mode
 
 
 def _forget_dispatch(run_id: str, task: asyncio.Task[None]) -> None:
@@ -177,9 +166,7 @@ async def dispatch_operations_agent_run(run_id: str) -> None:
                 # deep-run profile. Binding validation supplies the hard
                 # ceiling; this fills/raises the inner timeout to that profile.
                 runtime_config["timeout_seconds"] = binding.dispatch_timeout_seconds
-            runtime_config["permission_mode"] = _runtime_permission_mode(
-                selection["runtime"], profile.mode
-            )
+            runtime_config["permission_mode"] = profile.mode
             permissions = contract.tool_policy
 
         state_contract_error: str | None = None

--- a/backend/workflow/opencli_hda_tracer.py
+++ b/backend/workflow/opencli_hda_tracer.py
@@ -5109,7 +5109,7 @@ async def _execute_feishu_bitable_sink(
                 code=f"feishu_{exc.kind}",
                 message="Feishu Bitable delivery failed.",
                 details={**safe_details, "errorKind": exc.kind},
-                event_type="failed",
+                event_type="blocked" if exc.kind == "delivery_in_progress" else "failed",
             ) from exc
         delivery_refs.append(
             {

--- a/backend/ws_agent_manager.py
+++ b/backend/ws_agent_manager.py
@@ -258,9 +258,11 @@ async def resolve_agent_event(request_id: str, msg: dict[str, Any]) -> None:
     event = msg.get("event", {})
     try:
         await _invoke_on_event(on_event, event)
-    except Exception:
+    except Exception as exc:
         logger.exception("WS: on_event callback raised for request_id=%s", request_id)
-
+        fut = _pending_agent_tasks.get(request_id)
+        if fut is not None and not fut.done():
+            fut.set_exception(exc)
 
 def resolve_agent_result(request_id: str, msg: dict[str, Any]) -> None:
     """Called from the WS receive loop when an agent sends the terminal 'agent_result' frame."""

--- a/frontend/app/(app)/operations-agents/page.tsx
+++ b/frontend/app/(app)/operations-agents/page.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 import AgentAvatar from '@/components/smoothui/agent-avatar'
 import SwitchboardCard from '@/components/smoothui/switchboard-card'
 import { useAutomations, useCreateAutomation, useGovernedWorkspaces, useInstallAutomationStarters, useOperationsAgentActivity, useOperationsAgentDraft, useOperationsAgents, useOperationsAgentVersion, useOperationsAgentVersions, usePatchAutomation, usePublishOperationsAgentVersion, useStartOperationsAgentRun, useUpdateOperationsAgentDraft } from '@/lib/api/hooks'
-import type { AgentRuntimeBindingV1, Automation, OperationsAgent, OperationsAgentMode } from '@/lib/api/types'
+import type { AgentRuntimeBindingV2, Automation, OperationsAgent, OperationsAgentMode } from '@/lib/api/types'
 import { cn } from '@/lib/utils'
 import { BACKEND_HINT, EmptyState, ErrorState, LoadingState } from '@/components/shell/data-states'
 import { Button } from '@/components/ui/button'
@@ -120,7 +120,7 @@ function ContractEditor({ workspaceId, agent }: { workspaceId: string; agent: Op
   const [outputSchema, setOutputSchema] = useState('')
   const [stateSchema, setStateSchema] = useState('')
   const [agentUrl, setAgentUrl] = useState('')
-  const [runtime, setRuntime] = useState<AgentRuntimeBindingV1['runtime']>('pi')
+  const [runtime, setRuntime] = useState<AgentRuntimeBindingV2['preferred_runtimes'][number]>('pi')
   const [workflow, setWorkflow] = useState('')
   const [dispatchTimeout, setDispatchTimeout] = useState(1800)
   const [runtimeConfig, setRuntimeConfig] = useState('')
@@ -152,8 +152,8 @@ function ContractEditor({ workspaceId, agent }: { workspaceId: string; agent: Op
     setInputSchema(JSON.stringify(contract?.input_schema ?? EMPTY_SCHEMA, null, 2))
     setOutputSchema(JSON.stringify(contract?.output_schema ?? EMPTY_SCHEMA, null, 2))
     setStateSchema(JSON.stringify(contract?.state_schema ?? EMPTY_SCHEMA, null, 2))
-    setAgentUrl(binding?.agent_url ?? '')
-    setRuntime(binding?.runtime ?? 'pi')
+    setAgentUrl(binding?.preferred_agent_urls?.[0] ?? '')
+    setRuntime(binding?.preferred_runtimes?.[0] ?? 'pi')
     setWorkflow(binding?.workflow ?? '')
     setDispatchTimeout(binding?.dispatch_timeout_seconds ?? 1800)
     setRuntimeConfig(JSON.stringify(binding?.config ?? { timeout_seconds: 1800 }, null, 2))
@@ -189,12 +189,9 @@ function ContractEditor({ workspaceId, agent }: { workspaceId: string; agent: Op
               evidence_requirements: parseIdentifierList(evidenceRequirements),
             },
             runtime_binding: {
-              ...(binding ?? {}),
-              schema_version: 'agent.runtime-binding.v1',
-              agent_url: agentUrl.trim(),
-              runtime,
+              schema_version: 'agent.runtime-binding.v2',
               workflow: workflow.trim(),
-              preferred_agent_urls: agentUrl ? [agentUrl.trim()] : [],
+              preferred_agent_urls: agentUrl.trim() ? [agentUrl.trim()] : [],
               preferred_runtimes: runtime ? [runtime] : [],
               model_binding: provider.trim() && model.trim() ? {
                 schema_version: 'agent.model-binding.v1',
@@ -258,7 +255,7 @@ function ContractEditor({ workspaceId, agent }: { workspaceId: string; agent: Op
             <summary className="cursor-pointer text-sm text-muted-foreground">Runtime Binding 高级配置</summary>
             <div className="mt-4 grid gap-4 sm:grid-cols-4">
               <label className="space-y-1.5 text-xs text-muted-foreground">Agent URL<Input type="url" value={agentUrl} onChange={(event) => setAgentUrl(event.target.value)} placeholder="https://agent.example.com" /></label>
-              <label className="space-y-1.5 text-xs text-muted-foreground">Runtime<select value={runtime} onChange={(event) => setRuntime(event.target.value as AgentRuntimeBindingV1['runtime'])} className="h-9 w-full rounded-lg border bg-background px-3 text-sm text-foreground"><option value="miniflow">MiniFlow</option><option value="pi">Pi</option><option value="codex">Codex</option></select></label>
+              <label className="space-y-1.5 text-xs text-muted-foreground">Runtime<select value={runtime} onChange={(event) => setRuntime(event.target.value as AgentRuntimeBindingV2['preferred_runtimes'][number])} className="h-9 w-full rounded-lg border bg-background px-3 text-sm text-foreground"><option value="miniflow">MiniFlow</option><option value="pi">Pi</option><option value="codex">Codex</option></select></label>
               <label className="space-y-1.5 text-xs text-muted-foreground">Workflow<Input value={workflow} onChange={(event) => setWorkflow(event.target.value)} placeholder="default" /></label>
               <label className="space-y-1.5 text-xs text-muted-foreground">深度执行超时（秒）<Input type="number" min={1} max={3600} value={dispatchTimeout} onChange={(event) => setDispatchTimeout(Number(event.target.value))} /><span className="block text-[11px] leading-4 text-muted-foreground">默认 30 分钟；本地 CLI 不暴露 5 小时额度，因此不伪造剩余额度。</span></label>
             </div>

--- a/frontend/app/(app)/plugins/page.tsx
+++ b/frontend/app/(app)/plugins/page.tsx
@@ -235,6 +235,42 @@ function PluginSubtypeTabs({
     </nav>
   )
 }
+function PluginPageTabs({
+  active,
+  onSelect,
+}: {
+  active: PluginPageTab
+  onSelect: (tab: PluginPageTab) => void
+}) {
+  const tabs: Array<[PluginPageTab, string]> = [
+    ['installed', '已安装'],
+    ['capabilities', '能力目录'],
+    ['marketplace', '探索市场'],
+  ]
+  return (
+    <nav aria-label="插件中心视图" className="no-scrollbar overflow-x-auto">
+      <div className="inline-flex min-w-max items-center gap-1 rounded-lg bg-muted p-1">
+        {tabs.map(([key, label]) => (
+          <button
+            key={key}
+            type="button"
+            aria-current={active === key ? 'page' : undefined}
+            onClick={() => onSelect(key)}
+            className={cn(
+              'relative min-h-10 rounded-md px-4 text-sm font-medium transition-colors',
+              active === key
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </nav>
+  )
+}
+
 
 function ProviderCard({
   provider,
@@ -682,37 +718,40 @@ export default function PluginHubPage() {
       : '管理当前工作区已安装的 Provider。未安装、未启用或缺少运行绑定的能力会明确显示为受阻。'
 
   const topTabs = (
-    <div className="flex w-full flex-wrap items-center justify-between gap-3">
-      <PluginSubtypeTabs active={activeSubtype} onSelect={updateSubtype} />
-      <div className="flex flex-wrap items-center gap-2">
-        <select
-          aria-label="插件工作区"
-          className="min-h-10 rounded-md border bg-background px-3 text-sm"
-          value={workspaceId ?? ''}
-          onChange={(event) => {
-            const params = new URLSearchParams(searchParams.toString())
-            if (event.target.value) params.set('workspace', event.target.value)
-            else params.delete('workspace')
-            router.push(`/plugins?${params.toString()}`, { scroll: false })
-          }}
-          disabled={workspaces.isLoading || !workspaces.data?.length}
-        >
-          <option value="">选择工作区</option>
-          {workspaces.data?.map((workspace) => (
-            <option key={workspace.id} value={workspace.id}>{workspace.name}</option>
-          ))}
-        </select>
-        <Button
-          variant="outline"
-          size="sm"
-          className="min-h-10"
-          onClick={() => setDifyImportOpen(true)}
-          disabled={!workspaceId}
-        >
-          <Download aria-hidden="true" className="size-4" />
-          安装插件包
-        </Button>
+    <div className="flex w-full flex-col gap-3">
+      <div className="flex w-full flex-wrap items-center justify-between gap-3">
+        <PluginPageTabs active={activeTab} onSelect={(tab) => updateRoute({ tab })} />
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            aria-label="插件工作区"
+            className="min-h-10 rounded-md border bg-background px-3 text-sm"
+            value={workspaceId ?? ''}
+            onChange={(event) => {
+              const params = new URLSearchParams(searchParams.toString())
+              if (event.target.value) params.set('workspace', event.target.value)
+              else params.delete('workspace')
+              router.push(`/plugins?${params.toString()}`, { scroll: false })
+            }}
+            disabled={workspaces.isLoading || !workspaces.data?.length}
+          >
+            <option value="">选择工作区</option>
+            {workspaces.data?.map((workspace) => (
+              <option key={workspace.id} value={workspace.id}>{workspace.name}</option>
+            ))}
+          </select>
+          <Button
+            variant="outline"
+            size="sm"
+            className="min-h-10"
+            onClick={() => setDifyImportOpen(true)}
+            disabled={!workspaceId}
+          >
+            <Download aria-hidden="true" className="size-4" />
+            安装插件包
+          </Button>
+        </div>
       </div>
+      <PluginSubtypeTabs active={activeSubtype} onSelect={updateSubtype} />
     </div>
   )
   async function toggleInstallation(installation: BackendPluginInstallation) {

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -1325,15 +1325,19 @@ export interface AgentContractV1 {
   state_schema: Record<string, unknown>;
 }
 
-export interface AgentRuntimeBindingV1 {
-  schema_version: "agent.runtime-binding.v1";
-  agent_url: string;
-  runtime: "miniflow" | "pi" | "codex";
+export interface AgentRuntimeBindingV2 {
+  schema_version: "agent.runtime-binding.v2";
   workflow: string;
+  preferred_agent_urls: string[];
+  preferred_runtimes: Array<"miniflow" | "pi" | "codex">;
+  model_binding: {
+    schema_version: "agent.model-binding.v1";
+    provider: string;
+    model: string;
+    auth_profile: string | null;
+  } | null;
   config: Record<string, unknown>;
   dispatch_timeout_seconds: number;
-  execution_node_url?: string | null;
-  shared_filesystem_id?: string | null;
 }
 
 export interface OperationsAgentDraft {
@@ -1341,7 +1345,7 @@ export interface OperationsAgentDraft {
   instructions: string;
   model_configuration: Record<string, unknown> & {
     agent_contract?: AgentContractV1;
-    runtime_binding?: AgentRuntimeBindingV1;
+    runtime_binding?: AgentRuntimeBindingV2;
   };
   tool_configuration: Record<string, unknown>;
   updated_by_user_id: string;

--- a/frontend/scripts/check-control-plane-regressions.mjs
+++ b/frontend/scripts/check-control-plane-regressions.mjs
@@ -34,13 +34,13 @@ test('plugin hub keeps provider management without hiding provider capabilities'
   for (const label of ['模型', '工具', '数据源', 'Agent 策略', '触发器', '扩展', '工具包']) {
     assert.match(providerCatalog, new RegExp(label))
   }
-  assert.match(plugins, /useWorkflowCapabilities\(true\)/)
+  assert.match(plugins, /useWorkflowCapabilities\(true,\s*workspaceId\)/)
   assert.match(plugins, /PLUGIN_PROVIDERS/)
   assert.match(plugins, /安装插件包/)
-  assert.match(plugins, /router\.push\('\/plugins\/opencli'\)/)
+  assert.match(plugins, /router\.push\([\s\S]*\/plugins\/opencli/)
   assert.match(plugins, /RssCatalogImportDialog/)
   assert.match(plugins, /DifyPackageImportDialog/)
-  assert.match(plugins, /useBackendPluginCatalog\(true\)/)
+  assert.match(plugins, /useBackendPluginCatalog\(workspaceId\)/)
   assert.match(plugins, /导入 OPML 订阅清单/)
   assert.match(providerCatalog, /category: 'datasource'/)
   assert.match(providerCatalog, /category: 'tool'/)

--- a/tests/unit/test_agent_server.py
+++ b/tests/unit/test_agent_server.py
@@ -97,6 +97,39 @@ async def test_direct_http_runtime_endpoint_rejects_codex(monkeypatch):
     assert blocked.value.status_code == 403
 
 
+
+@pytest.mark.asyncio
+async def test_direct_http_runtime_endpoint_rejects_runtime_outside_installed_bundle(monkeypatch):
+    monkeypatch.setattr(agent_server, "_AGENT_API_TOKEN", "secret")
+    monkeypatch.setattr(agent_server, "_bundle_declared_runtimes", lambda: {"script-host"})
+    request = agent_runtime_dispatch.RuntimeInvokeRequest(
+        runtime="pi",
+        workflow="inspect",
+        instructions="inspect",
+    )
+
+    with pytest.raises(HTTPException) as blocked:
+        await agent_server.invoke_runtime_http(request, "Bearer secret")
+
+    assert blocked.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_direct_http_runtime_endpoint_rejects_process_overrides(monkeypatch):
+    monkeypatch.setattr(agent_server, "_AGENT_API_TOKEN", "secret")
+    monkeypatch.setattr(agent_server, "_bundle_declared_runtimes", lambda: {"script-host"})
+    request = agent_runtime_dispatch.RuntimeInvokeRequest(
+        runtime="script-host",
+        workflow="page.metadata",
+        instructions="inspect",
+        config={"pack": "page-basics", "binary": "python"},
+    )
+
+    with pytest.raises(HTTPException) as blocked:
+        await agent_server.invoke_runtime_http(request, "Bearer secret")
+
+    assert blocked.value.status_code == 400
+
 # ── _register_with_center attaches Authorization header ────────────────────
 
 
@@ -522,6 +555,33 @@ async def test_runtime_invoke_routes_script_host_without_generic_adapter(monkeyp
         )
         == expected
     )
+
+
+@pytest.mark.asyncio
+async def test_runtime_invoke_rejects_truncated_nonterminal_stream(monkeypatch):
+    class TruncatedAdapter:
+        def validate_config(self, config):
+            return []
+
+        async def invoke(self, task):
+            yield {"type": "started", "task_id": task.task_id}
+
+    request = agent_runtime_dispatch.RuntimeInvokeRequest(
+        runtime="pi",
+        workflow="inspect",
+        instructions="inspect",
+    )
+    monkeypatch.setattr(agent_runtime_dispatch, "get_runtime", lambda runtime: TruncatedAdapter())
+
+    with pytest.raises(HTTPException) as failed:
+        await agent_runtime_dispatch.invoke_runtime(
+            "request-1",
+            request,
+            cdp_endpoint="http://localhost:9222",
+        )
+
+    assert failed.value.status_code == 502
+    assert "terminal event" in str(failed.value.detail)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_feishu_bitable_delivery.py
+++ b/tests/unit/test_feishu_bitable_delivery.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -82,6 +83,88 @@ async def test_delivery_is_idempotent_per_target_and_record(db_session):
     assert second.status == "succeeded"
     create.assert_awaited_once()
 
+
+@pytest.mark.asyncio
+async def test_fresh_pending_attempt_is_explicitly_in_progress(db_session):
+    connection = DeliveryConnection(
+        name="Feishu", app_id="cli_test", app_secret="secret", enabled=True
+    )
+    db_session.add(connection)
+    await db_session.flush()
+    db_session.add(
+        DeliveryAttempt(
+            connection_id=connection.id,
+            app_token="app_token",
+            table_id="table",
+            record_id="record-1",
+            workflow_run_id="run-1",
+            evidence_digest="a" * 64,
+            field_map={"recordId": "Record ID"},
+            status="pending",
+        )
+    )
+    await db_session.commit()
+
+    with patch(
+        "backend.services.feishu_bitable_delivery.create_record",
+        new=AsyncMock(return_value="remote-1"),
+    ) as create:
+        with pytest.raises(FeishuDeliveryError, match="delivery_in_progress"):
+            await deliver_record_once(
+                db_session,
+                connection=connection,
+                app_token="app_token",
+                table_id="table",
+                record_id="record-1",
+                workflow_run_id="run-1",
+                evidence_digest="a" * 64,
+                fields={"Record ID": "record-1"},
+                field_map={"recordId": "Record ID"},
+            )
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stale_pending_attempt_can_retry_after_reservation_crash(db_session):
+    connection = DeliveryConnection(
+        name="Feishu", app_id="cli_test", app_secret="secret", enabled=True
+    )
+    db_session.add(connection)
+    await db_session.flush()
+    stale = DeliveryAttempt(
+        connection_id=connection.id,
+        app_token="app_token",
+        table_id="table",
+        record_id="record-1",
+        workflow_run_id="run-1",
+        evidence_digest="a" * 64,
+        field_map={"recordId": "Record ID"},
+        status="pending",
+        updated_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+    )
+    db_session.add(stale)
+    await db_session.commit()
+
+    with patch(
+        "backend.services.feishu_bitable_delivery.create_record",
+        new=AsyncMock(return_value="remote-1"),
+    ) as create:
+        retried = await deliver_record_once(
+            db_session,
+            connection=connection,
+            app_token="app_token",
+            table_id="table",
+            record_id="record-1",
+            workflow_run_id="run-1",
+            evidence_digest="a" * 64,
+            fields={"Record ID": "record-1"},
+            field_map={"recordId": "Record ID"},
+        )
+
+    assert retried.id == stale.id
+    assert retried.status == "succeeded"
+    assert retried.remote_record_id == "remote-1"
+    create.assert_awaited_once()
 
 @pytest.mark.asyncio
 async def test_probe_bitable_uses_official_host_and_counts_fields():

--- a/tests/unit/test_operations_agent_runtime_service.py
+++ b/tests/unit/test_operations_agent_runtime_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import pytest
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -11,17 +12,6 @@ from backend.models.operations_agent import (
     PublishedOperationsAgentVersion,
 )
 from backend.services import operations_agent_runtime_service
-
-
-def test_runtime_permission_mode_maps_observe_only_for_codex():
-    assert (
-        operations_agent_runtime_service._runtime_permission_mode("codex", "observe_only")
-        == "read_only"
-    )
-    assert (
-        operations_agent_runtime_service._runtime_permission_mode("claude-code", "observe_only")
-        == "observe_only"
-    )
 
 
 def _model_configuration() -> dict:
@@ -65,12 +55,12 @@ def _model_configuration() -> dict:
     }
 
 
-def _stub_runtime_selection(monkeypatch) -> None:
+def _stub_runtime_selection(monkeypatch, runtime: str = "pi") -> None:
     async def select_agent_runtime(*args, **kwargs):
         return {
             "schema_version": "agent.runtime-selection.v1",
             "agent_url": "http://agent-runtime.test:19823",
-            "runtime": "pi",
+            "runtime": runtime,
             "workflow": "operations-agent",
             "capabilities": ["model_selection", "streaming", "tool_events"],
             "provider": "openrouter",
@@ -144,13 +134,14 @@ async def _seed_run(db_session) -> OperationsAgentRun:
     return run
 
 
+@pytest.mark.parametrize("runtime", ["pi", "codex"])
 async def test_dispatch_uses_existing_runtime_protocol_and_validates_result(
-    db_engine, db_session, monkeypatch
+    db_engine, db_session, monkeypatch, runtime
 ):
     run = await _seed_run(db_session)
     session_factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
     monkeypatch.setattr(operations_agent_runtime_service, "AsyncSessionLocal", session_factory)
-    _stub_runtime_selection(monkeypatch)
+    _stub_runtime_selection(monkeypatch, runtime=runtime)
     captured_task = {}
 
     async def send_agent_task(agent_url, task, on_event, timeout):
@@ -183,7 +174,7 @@ async def test_dispatch_uses_existing_runtime_protocol_and_validates_result(
     await operations_agent_runtime_service.dispatch_operations_agent_run(run.id)
 
     await db_session.refresh(run)
-    assert captured_task["runtime"] == "pi"
+    assert captured_task["runtime"] == runtime
     assert captured_task["instructions"] == "Inspect the requested target"
     assert captured_task["input"] == {"target_id": "daily-news"}
     assert captured_task["config"]["permission_mode"] == "observe_only"
@@ -192,7 +183,7 @@ async def test_dispatch_uses_existing_runtime_protocol_and_validates_result(
     assert run.state_payload == {"last_target_id": "daily-news"}
     assert run.output_payload == {"summary": "Target inspected"}
     assert run.error_message is None
-    assert run.execution_binding["runtime"] == "pi"
+    assert run.execution_binding["runtime"] == runtime
     assert run.evidence_payload["schema_version"] == "agent.run-evidence.v1"
     assert run.evidence_payload["audit"][1]["api_key"] == "[REDACTED]"
 

--- a/tests/unit/test_ws_agent_manager.py
+++ b/tests/unit/test_ws_agent_manager.py
@@ -319,10 +319,14 @@ def test_resolve_agent_result_already_done_future_no_error():
 
 
 @pytest.mark.asyncio
-async def test_resolve_agent_event_callback_exception_does_not_propagate():
-    """A raising on_event must be swallowed (logged), not break the dispatcher."""
+async def test_resolve_agent_event_callback_exception_fails_pending_task():
     def bad_on_event(event):
         raise ValueError("boom")
 
+    fut = asyncio.get_running_loop().create_future()
+    mgr._pending_agent_tasks["req-1"] = fut
     mgr._agent_task_callbacks["req-1"] = (bad_on_event, "http://agent:1")
-    await mgr.resolve_agent_event("req-1", {"event": {"type": "text"}})  # must not raise
+    await mgr.resolve_agent_event("req-1", {"event": {"type": "text"}})
+
+    with pytest.raises(ValueError, match="boom"):
+        await fut


### PR DESCRIPTION
Fixes post-merge review findings: recover stale Feishu delivery reservations while blocking fresh concurrent attempts, preserve Codex observe_only vocabulary, reject incomplete runtime streams, propagate WS callback persistence failures, restrict HTTP runtime invocation to installed bundle capabilities and task-safe config, and align Operations Agent UI payloads with runtime-binding.v2. Restores Plugin Hub view navigation and updates stale static assertions.