### PR TITLE
feat(browser-act): add Kuaishou search pack

### DIFF
--- a/backend/browser_act_packs/video-platforms/kuaishou-search/SKILL.md
+++ b/backend/browser_act_packs/video-platforms/kuaishou-search/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: kuaishou-search
+description: "Extract structured public Kuaishou video search results from the current browser page."
+---
+
+# Kuaishou — Video Search
+
+> Search keyword → bounded structured video results
+
+## Prerequisites
+
+- Browser Act is available.
+- The target browser can reach `kuaishou.com`.
+- The current session may need human login or verification.
+
+## Execution
+
+Navigate to:
+
+```text
+https://www.kuaishou.com/search/video?searchKey={query}
+```
+
+Wait for the page to settle, then run:
+
+```bash
+python scripts/extract-search.py --max-results 10
+```
+
+The result contains the video URL, caption, author, cover, playable media
+URL when exposed by the page, publication timestamp, tags, and bounded
+engagement statistics.
+
+## Operational boundary
+
+This pack reads the public search state already present in the browser. It
+never automates login, captcha solving, or anti-bot bypass. Login, verification,
+regional restrictions, and blocked responses are human-handled conditions.
+
+## Limitations
+
+The manifest extracts the initial search result state only. Cursor-based
+follow-up requests and comment collection are intentionally out of scope for
+this pack; they require a separate pagination contract and should not be
+silently represented as complete results.

--- a/backend/browser_act_packs/video-platforms/kuaishou-search/channel.manifest.json
+++ b/backend/browser_act_packs/video-platforms/kuaishou-search/channel.manifest.json
@@ -1,0 +1,15 @@
+{
+  "domain": "video-platforms",
+  "capability": "kuaishou-search",
+  "param_schema": [
+    {"name": "query", "required": true},
+    {"name": "max_results", "required": false, "default": "10"}
+  ],
+  "steps": [
+    {"op": "navigate", "url_template": "https://www.kuaishou.com/search/video?searchKey={query}"},
+    {"op": "wait", "wait_mode": "stable"},
+    {"op": "eval_script", "script": "scripts/extract-search.py", "args": ["--max-results", "{max_results}"]}
+  ],
+  "pagination": {"mode": "none"},
+  "success": {"min_count": 1, "required_field": "url"}
+}

--- a/backend/browser_act_packs/video-platforms/kuaishou-search/scripts/extract-search.py
+++ b/backend/browser_act_packs/video-platforms/kuaishou-search/scripts/extract-search.py
@@ -1,0 +1,88 @@
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-results", type=int, default=10)
+    args = parser.parse_args()
+    max_results = max(1, min(args.max_results, 50))
+
+    js = r"""(() => {
+  const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+  const firstUrl = (value) => {
+    if (typeof value === 'string' && value) return value;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const result = firstUrl(item);
+        if (result) return result;
+      }
+    }
+    if (value && typeof value === 'object') {
+      for (const key of ['url', 'src', 'srcNoWatermark', 'playUrl']) {
+        const result = firstUrl(value[key]);
+        if (result) return result;
+      }
+    }
+    return null;
+  };
+  const isoTime = (value) => {
+    const timestamp = Number(value);
+    if (!Number.isFinite(timestamp) || timestamp <= 0) return null;
+    const date = new Date(timestamp < 100000000000 ? timestamp * 1000 : timestamp);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  };
+  const stateValues = Object.values(window.INIT_STATE || {});
+  const state = stateValues.find((value) => value && Array.isArray(value.feeds)) || {feeds: []};
+  const items = state.feeds.map((feed) => {
+    if (!feed || typeof feed !== 'object') return null;
+    const photo = feed.photo && typeof feed.photo === 'object' ? feed.photo : null;
+    if (!photo || !clean(photo.id)) return null;
+    const author = feed.author && typeof feed.author === 'object' ? feed.author : {};
+    const comment = feed.comment && typeof feed.comment === 'object' ? feed.comment : {};
+    const photoId = clean(photo.id);
+    const caption = clean(photo.caption);
+    const coverUrl = firstUrl(photo.coverUrl);
+    const playUrl = firstUrl(photo.manifestH265) || firstUrl(photo.manifest);
+    const statistics = {
+      like_count: photo.likeCount,
+      comment_count: comment.us_c,
+      collect_count: photo.collectCount,
+      view_count: photo.viewCount,
+      share_count: photo.shareCount,
+    };
+    Object.keys(statistics).forEach((key) => {
+      if (statistics[key] === null || statistics[key] === undefined) delete statistics[key];
+    });
+    return {
+      title: caption || `Kuaishou video ${photoId}`,
+      content: caption,
+      author: clean(author.name),
+      author_id: clean(author.id) || null,
+      author_avatar: firstUrl(author.headerUrl),
+      url: `https://www.kuaishou.com/short-video/${encodeURIComponent(photoId)}`,
+      photo_id: photoId,
+      create_time: photo.timestamp || null,
+      published_at: isoTime(photo.timestamp),
+      cover_url: coverUrl,
+      play_url: playUrl,
+      statistics,
+      media: {
+        type: 'video',
+        play_url: playUrl,
+        cover_url: coverUrl,
+        duration_ms: photo.duration || null,
+        width: photo.width || null,
+        height: photo.height || null,
+      },
+      tags: Array.isArray(feed.tags)
+        ? feed.tags.map((tag) => clean(tag && tag.name)).filter(Boolean)
+        : [],
+    };
+  }).filter(Boolean).slice(0, MAX_RESULTS);
+  return {count: items.length, items};
+})()"""
+    print(js.replace("MAX_RESULTS", str(max_results)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_browser_act_packs_api.py
+++ b/tests/integration/test_browser_act_packs_api.py
@@ -18,6 +18,7 @@ SEEDED_WITH_MANIFEST = {
     "ecommerce/taobao-product-reviews",
     "ecommerce/taobao-shop-catalog",
     "search-research/google-search-serp",
+    "video-platforms/kuaishou-search",
 }
 
 

--- a/tests/unit/browser_act_packs/test_kuaishou_pack.py
+++ b/tests/unit/browser_act_packs/test_kuaishou_pack.py
@@ -1,0 +1,35 @@
+"""Contract checks for the Kuaishou Browser Act pack."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from backend.browser_act_packs.catalog import PackCatalog
+from backend.browser_act_packs.manifest import load_manifest
+
+_PACK = Path(PackCatalog().root) / "video-platforms" / "kuaishou-search"
+
+
+def test_kuaishou_manifest_points_to_bounded_search_script() -> None:
+    manifest = load_manifest(_PACK / "channel.manifest.json")
+
+    assert manifest.domain == "video-platforms"
+    assert manifest.capability == "kuaishou-search"
+    assert manifest.success.required_field == "url"
+    assert manifest.pagination.mode == "none"
+    assert manifest.steps[-1].script == "scripts/extract-search.py"
+    assert (_PACK / manifest.steps[-1].script).is_file()
+
+
+def test_kuaishou_script_emits_requested_result_bound() -> None:
+    script = _PACK / "scripts" / "extract-search.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--max-results", "7"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "MAX_RESULTS" not in result.stdout
+    assert ".slice(0, 7)" in result.stdout
+    assert "kuaishou.com/short-video" in result.stdout

--- a/tests/unit/browser_act_packs/test_kuaishou_pack.py
+++ b/tests/unit/browser_act_packs/test_kuaishou_pack.py
@@ -1,35 +1,99 @@
-"""Contract checks for the Kuaishou Browser Act pack."""
+"""Behavioral checks for the Kuaishou Browser Act pack."""
 
+import json
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from backend.browser_act_packs.catalog import PackCatalog
-from backend.browser_act_packs.manifest import load_manifest
 
 _PACK = Path(PackCatalog().root) / "video-platforms" / "kuaishou-search"
 
 
-def test_kuaishou_manifest_points_to_bounded_search_script() -> None:
-    manifest = load_manifest(_PACK / "channel.manifest.json")
-
-    assert manifest.domain == "video-platforms"
-    assert manifest.capability == "kuaishou-search"
-    assert manifest.success.required_field == "url"
-    assert manifest.pagination.mode == "none"
-    assert manifest.steps[-1].script == "scripts/extract-search.py"
-    assert (_PACK / manifest.steps[-1].script).is_file()
-
-
-def test_kuaishou_script_emits_requested_result_bound() -> None:
-    script = _PACK / "scripts" / "extract-search.py"
-    result = subprocess.run(
-        [sys.executable, str(script), "--max-results", "7"],
+def _extract(state: dict, max_results: int) -> dict:
+    script = subprocess.run(
+        [
+            sys.executable,
+            str(_PACK / "scripts" / "extract-search.py"),
+            "--max-results",
+            str(max_results),
+        ],
         check=True,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        timeout=30,
+    ).stdout
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            "const fs = require('node:fs');"
+            "const {state, script} = JSON.parse(fs.readFileSync(0, 'utf8'));"
+            "globalThis.window = {INIT_STATE: state};"
+            "console.log(JSON.stringify(eval(script)));",
+        ],
+        input=json.dumps({"state": state, "script": script}, ensure_ascii=False),
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+    return json.loads(result.stdout)
+
+
+def test_search_returns_bounded_records_after_skipping_invalid_feeds() -> None:
+    result = _extract(
+        {
+            "search": {
+                "feeds": [
+                    None,
+                    {"photo": {"caption": "Missing ID"}},
+                    {
+                        "photo": {
+                            "id": "a/b",
+                            "caption": "  快手\n 视频  ",
+                            "timestamp": 1700000000,
+                            "likeCount": 0,
+                            "coverUrl": [{"url": "https://media.example/cover.jpg"}],
+                            "manifest": {"playUrl": "https://media.example/video.mp4"},
+                        },
+                        "author": {"name": "  Alice  "},
+                    },
+                    {"photo": {"id": "second"}},
+                    {"photo": {"id": "third"}},
+                ]
+            }
+        },
+        2,
     )
 
-    assert "MAX_RESULTS" not in result.stdout
-    assert ".slice(0, 7)" in result.stdout
-    assert "kuaishou.com/short-video" in result.stdout
+    assert result["count"] == 2
+    assert [item["url"] for item in result["items"]] == [
+        "https://www.kuaishou.com/short-video/a%2Fb",
+        "https://www.kuaishou.com/short-video/second",
+    ]
+    first = result["items"][0]
+    assert first["title"] == "快手 视频"
+    assert first["author"] == "Alice"
+    assert first["published_at"] == "2023-11-14T22:13:20.000Z"
+    assert first["statistics"] == {"like_count": 0}
+    assert first["cover_url"] == "https://media.example/cover.jpg"
+    assert first["play_url"] == "https://media.example/video.mp4"
+
+
+@pytest.mark.parametrize(("requested", "expected"), [(0, 1), (100, 50)])
+def test_search_clamps_result_limit(requested: int, expected: int) -> None:
+    feeds = [{"photo": {"id": str(index)}} for index in range(51)]
+
+    result = _extract({"search": {"feeds": feeds}}, requested)
+
+    assert result["count"] == expected
+    assert [item["photo_id"] for item in result["items"]] == [
+        str(index) for index in range(expected)
+    ]
+
+
+def test_search_without_initial_state_returns_no_records() -> None:
+    assert _extract({}, 10) == {"count": 0, "items": []}


### PR DESCRIPTION
## Problem

The repository has Browser Act packs for multiple web and video platforms, but it does not have an executable pack for public Kuaishou video search. This leaves Kuaishou outside the generic workflow catalog.

## Changes

- Add a `video-platforms/kuaishou-search` Browser Act pack.
- Navigate to the public Kuaishou video search page and extract the initial `window.INIT_STATE` feed.
- Return bounded structured records with video URL, caption, author, media URLs, publication time, tags, and engagement statistics when exposed by the page.
- Add a manifest and contract tests for the pack and its result bound.
- Register the seeded pack in the existing catalog API regression fixture.

## Compatibility and safety

- Uses the existing Browser Act manifest and CLI execution path; no direct CDP transport or new channel type is added.
- No new dependency, database migration, or public API route is introduced.
- The pack reads browser-visible state only. It does not automate login, captcha solving, or anti-bot bypass.
- Cursor-based follow-up requests and comment collection are explicitly out of scope for this initial pack; the manifest reports only the initial page as complete.

## Testing

On commit `8158f4cc325ba18d3903c34e4438e877a61737f7` (based on the current upstream `69c0ad1bca8ca4bfeb10ddd4541a17f831b38729`):

- `uv run --python 3.13 --extra dev python -m pytest tests/unit/browser_act_packs/test_kuaishou_pack.py tests/unit/browser_act_packs/test_manifest.py tests/integration/test_browser_act_packs_api.py tests/integration/test_browser_act_seeds.py tests/unit/channels/test_browser_act_channel.py --no-cov -q` — 50 passed.
- `uv run --python 3.13 --extra dev ruff check tests/unit/browser_act_packs/test_kuaishou_pack.py` — passed.
- Four behavioral cases execute the actual Python-generated JavaScript in Node with fixture state: filtering invalid feeds before bounding results, URL encoding and Unicode caption normalization, timestamp/media/statistics extraction, lower/upper limits, and absent state. Both subprocesses have 30-second timeouts and explicit UTF-8. This is fixture execution, not a live Kuaishou browser run.

On commit `65e76ac0`:

- `uv run pytest tests/unit/browser_act_packs/test_kuaishou_pack.py tests/unit/browser_act_packs/test_manifest.py tests/integration/test_browser_act_packs_api.py tests/integration/test_browser_act_seeds.py tests/unit/channels/test_browser_act_channel.py --no-cov -q` — 48 passed
- `uv run ruff check backend/browser_act_packs/video-platforms/kuaishou-search/scripts/extract-search.py tests/unit/browser_act_packs/test_kuaishou_pack.py tests/integration/test_browser_act_packs_api.py` — passed
- `git diff --check` — passed

No live Kuaishou browser run is claimed here. Login, verification, regional restrictions, anti-bot responses, and page-shape changes remain operational limitations.

## Non-goals

- Cursor pagination or comment collection.
- Automatic login, captcha solving, or anti-bot bypass.
- A new direct-browser channel implementation.
- Changes to existing Browser Act packs or browser runtime ownership.
