### PR TITLE
fix(ws): bind agent results to their dispatching connection

### DIFF
--- a/backend/api/v1/browsers.py
+++ b/backend/api/v1/browsers.py
@@ -655,11 +655,13 @@ async def agent_ws_endpoint(ws: WebSocket) -> None:
             msg = await ws.receive_json()
             msg_type = msg.get("type")
             if msg_type == "result":
-                ws_agent_manager.resolve_response(msg.get("request_id", ""), msg)
+                ws_agent_manager.resolve_response(msg.get("request_id", ""), msg, source_ws=ws)
             elif msg_type == "agent_event":
-                await ws_agent_manager.resolve_agent_event(msg.get("request_id", ""), msg)
+                await ws_agent_manager.resolve_agent_event(
+                    msg.get("request_id", ""), msg, source_ws=ws
+                )
             elif msg_type == "agent_result":
-                ws_agent_manager.resolve_agent_result(msg.get("request_id", ""), msg)
+                ws_agent_manager.resolve_agent_result(msg.get("request_id", ""), msg, source_ws=ws)
             elif msg_type == "ping":
                 await ws.send_json({"type": "pong"})
             else:
@@ -670,8 +672,7 @@ async def agent_ws_endpoint(ws: WebSocket) -> None:
     except Exception as exc:
         logger.exception("WS agent %s: unexpected error: %s", agent_url or "<unregistered>", exc)
     finally:
-        if agent_url:
-            ws_agent_manager.unregister_connection(agent_url)
+        if agent_url and ws_agent_manager.unregister_connection(agent_url, ws):
             try:
                 from datetime import datetime
 

--- a/backend/api/v1/nodes.py
+++ b/backend/api/v1/nodes.py
@@ -912,11 +912,13 @@ async def node_ws_endpoint(ws: WebSocket) -> None:
             msg = await ws.receive_json()
             msg_type = msg.get("type")
             if msg_type == "result":
-                ws_agent_manager.resolve_response(msg.get("request_id", ""), msg)
+                ws_agent_manager.resolve_response(msg.get("request_id", ""), msg, source_ws=ws)
             elif msg_type == "agent_event":
-                await ws_agent_manager.resolve_agent_event(msg.get("request_id", ""), msg)
+                await ws_agent_manager.resolve_agent_event(
+                    msg.get("request_id", ""), msg, source_ws=ws
+                )
             elif msg_type == "agent_result":
-                ws_agent_manager.resolve_agent_result(msg.get("request_id", ""), msg)
+                ws_agent_manager.resolve_agent_result(msg.get("request_id", ""), msg, source_ws=ws)
             elif msg_type == "ping":
                 await ws.send_json({"type": "pong"})
             else:
@@ -927,8 +929,7 @@ async def node_ws_endpoint(ws: WebSocket) -> None:
     except Exception as exc:
         logger.exception("WS node %s: error: %s", agent_url or "<unregistered>", exc)
     finally:
-        if agent_url:
-            ws_agent_manager.unregister_connection(agent_url)
+        if agent_url and ws_agent_manager.unregister_connection(agent_url, ws):
             # Write offline event
             try:
                 async with AsyncSessionLocal() as db:

--- a/backend/ws_agent_manager.py
+++ b/backend/ws_agent_manager.py
@@ -67,6 +67,8 @@ _connections: dict[str, WebSocket] = {}
 
 # request_id → Future awaiting agent result (collect/result path)
 _pending: dict[str, asyncio.Future] = {}
+_collect_owners: dict[str, WebSocket] = {}
+_task_owners: dict[str, WebSocket] = {}
 
 # request_id → Future awaiting the terminal agent_result (agent_task path)
 _pending_agent_tasks: dict[str, asyncio.Future] = {}
@@ -77,19 +79,24 @@ _agent_task_callbacks: dict[str, tuple[Callable[[dict[str, Any]], Any], str]] = 
 
 def register_connection(agent_url: str, ws: WebSocket) -> None:
     """Record a newly-established WS connection for agent_url."""
+    previous = _connections.get(agent_url)
+    if previous is not None and previous is not ws:
+        unregister_connection(agent_url, previous)
+        asyncio.get_running_loop().create_task(previous.close(code=1012))
     _connections[agent_url] = ws
     logger.info("WS agent connected: %s (total=%d)", agent_url, len(_connections))
 
 
-def unregister_connection(agent_url: str) -> None:
-    """Remove a WS connection and fail all its pending futures.
-
-    Collect-path futures (``_pending``) are left for their own timeout — no
-    request_id → agent_url reverse index exists for that path, matching prior
-    behavior. Agent-task futures (``_pending_agent_tasks``) ARE indexed by
-    owning agent_url, so on disconnect we resolve them immediately with an
-    AgentDisconnected error instead of leaving them to hang until timeout.
-    """
+def unregister_connection(agent_url: str, source_ws: WebSocket | None = None) -> bool:
+    """Fail this transport's pending work without unregistering a replacement."""
+    current = _connections.get(agent_url)
+    if current is None or (source_ws is not None and current is not source_ws):
+        return False
+    for request_id, owner in list(_collect_owners.items()):
+        if owner is current:
+            future = _pending.get(request_id)
+            if future is not None and not future.done():
+                future.set_exception(RuntimeError("Agent disconnected before collection completed"))
     _connections.pop(agent_url, None)
     logger.info("WS agent disconnected: %s (remaining=%d)", agent_url, len(_connections))
 
@@ -108,6 +115,7 @@ def unregister_connection(agent_url: str) -> None:
                 "error_type": "AgentDisconnected",
             })
         _agent_task_callbacks.pop(request_id, None)
+    return True
 
 
 def is_connected(agent_url: str) -> bool:
@@ -144,9 +152,12 @@ async def dispatch_collect(
         raise RuntimeError(f"No active WS connection for agent: {agent_url}")
 
     request_id = request_id or str(uuid.uuid4())
+    if request_id in _pending or request_id in _pending_agent_tasks:
+        raise ValueError("request_id is already active")
     loop = asyncio.get_running_loop()
     fut: asyncio.Future[dict] = loop.create_future()
     _pending[request_id] = fut
+    _collect_owners[request_id] = ws
 
     try:
         await ws.send_json({
@@ -169,11 +180,16 @@ async def dispatch_collect(
         raise
     finally:
         _pending.pop(request_id, None)
+        _collect_owners.pop(request_id, None)
 
 
-def resolve_response(request_id: str, result: dict[str, Any]) -> None:
+def resolve_response(
+    request_id: str, result: dict[str, Any], source_ws: WebSocket | None = None
+) -> None:
     """Called from the WS receive loop when an agent returns a 'result' message."""
     fut = _pending.get(request_id)
+    if source_ws is not None and _collect_owners.get(request_id) is not source_ws:
+        return
     if fut is None or fut.done():
         logger.warning("WS: unexpected result for request_id=%s (no waiting future)", request_id)
         return
@@ -213,6 +229,7 @@ async def send_agent_task(
     loop = asyncio.get_running_loop()
     fut: asyncio.Future[dict] = loop.create_future()
     _pending_agent_tasks[request_id] = fut
+    _task_owners[request_id] = ws
     _agent_task_callbacks[request_id] = (on_event, agent_url)
 
     try:
@@ -228,6 +245,7 @@ async def send_agent_task(
         raise
     finally:
         _pending_agent_tasks.pop(request_id, None)
+        _task_owners.pop(request_id, None)
         _agent_task_callbacks.pop(request_id, None)
 
 
@@ -248,11 +266,15 @@ async def _invoke_on_event(
         await result
 
 
-async def resolve_agent_event(request_id: str, msg: dict[str, Any]) -> None:
+async def resolve_agent_event(
+    request_id: str, msg: dict[str, Any], source_ws: WebSocket | None = None
+) -> None:
     """Called from the WS receive loop when an agent sends an 'agent_event' frame."""
     entry = _agent_task_callbacks.get(request_id)
     if entry is None:
         logger.warning("WS: unexpected agent_event for request_id=%s (no waiting task)", request_id)
+        return
+    if source_ws is not None and _task_owners.get(request_id) is not source_ws:
         return
     on_event, _owner = entry
     event = msg.get("event", {})
@@ -264,9 +286,13 @@ async def resolve_agent_event(request_id: str, msg: dict[str, Any]) -> None:
         if fut is not None and not fut.done():
             fut.set_exception(exc)
 
-def resolve_agent_result(request_id: str, msg: dict[str, Any]) -> None:
+def resolve_agent_result(
+    request_id: str, msg: dict[str, Any], source_ws: WebSocket | None = None
+) -> None:
     """Called from the WS receive loop when an agent sends the terminal 'agent_result' frame."""
     fut = _pending_agent_tasks.get(request_id)
+    if source_ws is not None and _task_owners.get(request_id) is not source_ws:
+        return
     if fut is None or fut.done():
         logger.warning(
             "WS: unexpected agent_result for request_id=%s (no waiting future)",

--- a/tests/unit/test_ws_connection_ownership.py
+++ b/tests/unit/test_ws_connection_ownership.py
@@ -1,0 +1,167 @@
+"""A reverse-channel peer may answer only work dispatched to its own socket."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend import ws_agent_manager as manager
+
+
+@pytest.fixture(autouse=True)
+def isolated_connections():
+    registries = (
+        manager._connections,
+        manager._pending,
+        manager._collect_owners,
+        manager._pending_agent_tasks,
+        manager._task_owners,
+        manager._agent_task_callbacks,
+    )
+    for registry in registries:
+        registry.clear()
+    yield
+    for registry in registries:
+        registry.clear()
+
+
+async def test_foreign_collection_result_cannot_complete_owned_work():
+    owner, foreign = AsyncMock(), AsyncMock()
+    sent = asyncio.Event()
+    manager.register_connection("agent", owner)
+
+    async def dispatch(payload):
+        manager.resolve_response(payload["request_id"], {"identity": "foreign"}, foreign)
+        sent.set()
+
+    owner.send_json.side_effect = dispatch
+    work = asyncio.create_task(
+        manager.dispatch_collect(
+            "agent", "site", "read", {}, [], "json", "bridge", request_id="owned"
+        )
+    )
+    await asyncio.wait_for(sent.wait(), 1)
+    assert not work.done()
+    manager.resolve_response("owned", {"identity": "owner"}, owner)
+    assert await work == {"identity": "owner"}
+
+
+async def test_foreign_streaming_events_and_terminal_results_are_ignored():
+    owner, foreign, event_handler = AsyncMock(), AsyncMock(), AsyncMock()
+    sent = asyncio.Event()
+    request_ids = []
+    manager.register_connection("agent", owner)
+
+    async def dispatch(payload):
+        request_ids.append(payload["request_id"])
+        await manager.resolve_agent_event(
+            payload["request_id"], {"event": {"text": "foreign"}}, foreign
+        )
+        manager.resolve_agent_result(
+            payload["request_id"], {"result": {"identity": "foreign"}}, foreign
+        )
+        sent.set()
+
+    owner.send_json.side_effect = dispatch
+    work = asyncio.create_task(manager.send_agent_task("agent", {"runtime": "pi"}, event_handler))
+    await asyncio.wait_for(sent.wait(), 1)
+    assert not work.done()
+    event_handler.assert_not_awaited()
+    await manager.resolve_agent_event(request_ids[0], {"event": {"text": "owner"}}, owner)
+    manager.resolve_agent_result(request_ids[0], {"result": {"identity": "owner"}}, owner)
+    assert await work == {"identity": "owner"}
+    event_handler.assert_awaited_once_with({"text": "owner"})
+
+
+async def test_disconnect_fails_pending_collect_without_waiting_for_timeout():
+    owner = AsyncMock()
+    sent = asyncio.Event()
+    owner.send_json.side_effect = lambda payload: sent.set()
+    manager.register_connection("agent", owner)
+    work = asyncio.create_task(
+        manager.dispatch_collect("agent", "site", "read", {}, [], "json", "bridge", timeout=60)
+    )
+    await asyncio.wait_for(sent.wait(), 1)
+    assert manager.unregister_connection("agent", owner)
+    with pytest.raises(RuntimeError, match="disconnected"):
+        await asyncio.wait_for(work, 1)
+    assert not manager._collect_owners
+
+
+async def test_replaced_socket_cannot_unregister_or_answer_replacement_work():
+    old, replacement = AsyncMock(), AsyncMock()
+    manager.register_connection("agent", old)
+    manager.register_connection("agent", replacement)
+    assert not manager.unregister_connection("agent", old)
+    assert manager.is_connected("agent")
+
+    async def dispatch(payload):
+        manager.resolve_response(payload["request_id"], {"identity": "old"}, old)
+        manager.resolve_response(payload["request_id"], {"identity": "replacement"}, replacement)
+
+    replacement.send_json.side_effect = dispatch
+    result = await manager.dispatch_collect("agent", "site", "read", {}, [], "json", "bridge")
+    assert result == {"identity": "replacement"}
+    await asyncio.sleep(0)
+    old.close.assert_awaited_once_with(code=1012)
+
+
+async def test_duplicate_request_does_not_replace_the_original_waiter():
+    owner = AsyncMock()
+    sent = asyncio.Event()
+    owner.send_json.side_effect = lambda payload: sent.set()
+    manager.register_connection("agent", owner)
+    work = asyncio.create_task(
+        manager.dispatch_collect(
+            "agent", "site", "read", {}, [], "json", "bridge", request_id="same"
+        )
+    )
+    await asyncio.wait_for(sent.wait(), 1)
+    with pytest.raises(ValueError, match="already active"):
+        await manager.dispatch_collect(
+            "agent", "site", "read", {}, [], "json", "bridge", request_id="same"
+        )
+    manager.resolve_response("same", {"identity": "original"}, owner)
+    assert await work == {"identity": "original"}
+
+
+@pytest.mark.parametrize("entrypoint", ["nodes", "browsers"])
+async def test_websocket_entrypoints_reject_foreign_frames(entrypoint, monkeypatch):
+    from unittest.mock import MagicMock
+
+    from starlette.websockets import WebSocketDisconnect
+
+    from backend import browser_pool, database
+    from backend.api.v1 import browsers, nodes
+
+    # Database availability is unrelated to message ownership. Exercise the real
+    # receive loops through their supported non-fatal DB-upsert failure path.
+    def unavailable_database():
+        raise RuntimeError("Controlled unavailable metadata store")
+
+    monkeypatch.setattr(database, "AsyncSessionLocal", unavailable_database)
+    monkeypatch.setattr(browser_pool, "get_pool", MagicMock(return_value=object()))
+    owner, peer = AsyncMock(), AsyncMock()
+    manager.register_connection("http://owner", owner)
+    collect = asyncio.get_running_loop().create_future()
+    terminal = asyncio.get_running_loop().create_future()
+    event_handler = AsyncMock()
+    manager._pending["collect"] = collect
+    manager._collect_owners["collect"] = owner
+    manager._pending_agent_tasks["stream"] = terminal
+    manager._task_owners["stream"] = owner
+    manager._agent_task_callbacks["stream"] = (event_handler, "http://owner")
+    peer.receive_json.side_effect = [
+        {"type": "register", "agent_url": "http://peer", "mode": "bridge", "node_type": "shell"},
+        {"type": "result", "request_id": "collect", "success": True},
+        {"type": "agent_event", "request_id": "stream", "event": {"text": "forged"}},
+        {"type": "agent_result", "request_id": "stream", "result": {"text": "forged"}},
+        WebSocketDisconnect(),
+    ]
+    handler = nodes.node_ws_endpoint if entrypoint == "nodes" else browsers.agent_ws_endpoint
+    await handler(peer)
+    assert peer.receive_json.await_count == 5
+    assert not collect.done()
+    assert not terminal.done()
+    event_handler.assert_not_awaited()
+    assert manager.is_connected("http://owner")


### PR DESCRIPTION
Reverse-channel peers could submit a guessed request ID to complete another connection's collection or streaming task. An older socket closing after a replacement connected could also unregister the replacement.

Bind pending work to the socket that received it, pass that socket through both WebSocket ingress routes, fail pending collection promptly on disconnect, and reject duplicate active collection IDs. The old socket can no longer answer replacement work or unregister it.

Validation: 29 targeted tests pass, including foreign collection/event/terminal frames, disconnect, replacement, duplicate IDs, and both WebSocket receive loops. Targeted Ruff and git diff --check pass. Independent review and repository CI are required before merge.

This is a self-contained security slice for the browser account work tracked in https://github.com/1012839419a-alt/opencli-Razormind-gjx/issues/40. It does not introduce account storage, new browser RPC, UI, installation, or the rest of parent #39.
